### PR TITLE
Feature: Path generators

### DIFF
--- a/config/filament-curator.php
+++ b/config/filament-curator.php
@@ -6,6 +6,7 @@ return [
     'media_resource' => \FilamentCurator\Resources\MediaResource::class,
     'disk' => 'public',
     'directory' => 'media',
+    'path_generator' => \FilamentCurator\Config\PathGenerator\DefaultPathGenerator::class,
     'visibility' => 'public',
     'preserve_file_names' => false,
     'accepted_file_types' => ['image/jpeg', 'image/png', 'image/webp', 'image/svg+xml', 'application/pdf'],

--- a/resources/lang/en/resource.php
+++ b/resources/lang/en/resource.php
@@ -14,6 +14,8 @@ return [
         'file' => 'File',
         'ext' => 'Ext',
         'updated_at' => 'Updated At',
-        'thumbnail_url' => 'Thumbnail'
+        'thumbnail_url' => 'Thumbnail',
+        'details' => 'Details',
+        'save' => 'Save'
     ],
 ];

--- a/resources/lang/it/alt-helper.php
+++ b/resources/lang/it/alt-helper.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'link' => "Informazioni su come descrivere un'immagine",
+    'link' => "Come descrivere un'immagine",
     'text' => "Lasciare il campo vuoto se l'immagine è puramente decorativa",
 ];

--- a/resources/lang/it/resource.php
+++ b/resources/lang/it/resource.php
@@ -9,7 +9,7 @@ return [
         'dimensions' => 'Dimensioni',
         'disk' => 'Disco',
         'directory' => 'Directory',
-        'public_id' => 'Id Pubblic',
+        'public_id' => 'Id Pubblico',
         'file_url' => 'URL del File',
         'file' => 'File',
         'ext' => 'Estensione',

--- a/resources/lang/it/resource.php
+++ b/resources/lang/it/resource.php
@@ -14,6 +14,8 @@ return [
         'file' => 'File',
         'ext' => 'Estensione',
         'updated_at' => 'Aggiornato',
-        'thumbnail_url' => 'Miniatura'
+        'thumbnail_url' => 'Miniatura',
+        'details' => 'Dettagli',
+        'save' => 'Salva'
     ],
 ];

--- a/src/Config/PathGenerator/DatePathGenerator.php
+++ b/src/Config/PathGenerator/DatePathGenerator.php
@@ -4,7 +4,7 @@ namespace FilamentCurator\Config\PathGenerator;
 
 use Carbon\Carbon;
 
-class WordpressPathGenerator implements PathGenerator
+class DatePathGenerator implements PathGenerator
 {
     public function getPath(?string $baseDir): string
     {

--- a/src/Config/PathGenerator/DatePathGenerator.php
+++ b/src/Config/PathGenerator/DatePathGenerator.php
@@ -6,7 +6,7 @@ use Carbon\Carbon;
 
 class DatePathGenerator implements PathGenerator
 {
-    public function getPath(?string $baseDir): string
+    public function getPath(?string $baseDir = null): string
     {
         $now = Carbon::now();
 

--- a/src/Config/PathGenerator/DefaultPathGenerator.php
+++ b/src/Config/PathGenerator/DefaultPathGenerator.php
@@ -6,6 +6,6 @@ class DefaultPathGenerator implements PathGenerator
 {
     public function getPath(?string $baseDir): string
     {
-        return ($baseDir ?? '') . '/';
+        return $baseDir ?? '';
     }
 }

--- a/src/Config/PathGenerator/DefaultPathGenerator.php
+++ b/src/Config/PathGenerator/DefaultPathGenerator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace FilamentCurator\Config\PathGenerator;
+
+class DefaultPathGenerator implements PathGenerator
+{
+    public function getPath(?string $baseDir): string
+    {
+        return ($baseDir ?? '') . '/';
+    }
+}

--- a/src/Config/PathGenerator/DefaultPathGenerator.php
+++ b/src/Config/PathGenerator/DefaultPathGenerator.php
@@ -4,7 +4,7 @@ namespace FilamentCurator\Config\PathGenerator;
 
 class DefaultPathGenerator implements PathGenerator
 {
-    public function getPath(?string $baseDir): string
+    public function getPath(?string $baseDir = null): string
     {
         return $baseDir ?? '';
     }

--- a/src/Config/PathGenerator/PathGenerator.php
+++ b/src/Config/PathGenerator/PathGenerator.php
@@ -4,5 +4,5 @@ namespace FilamentCurator\Config\PathGenerator;
 
 interface PathGenerator
 {
-    public function getPath(?string $baseDir): string;
+    public function getPath(?string $baseDir = null): string;
 }

--- a/src/Config/PathGenerator/PathGenerator.php
+++ b/src/Config/PathGenerator/PathGenerator.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace FilamentCurator\Config\PathGenerator;
+
+interface PathGenerator
+{
+    public function getPath(?string $baseDir): string;
+}

--- a/src/Config/PathGenerator/UserPathGenerator.php
+++ b/src/Config/PathGenerator/UserPathGenerator.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace FilamentCurator\Config\PathGenerator;
+
+use Illuminate\Support\Facades\Auth;
+
+class UserPathGenerator implements PathGenerator
+{
+    public function getPath(?string $baseDir): string
+    {
+        $user = Auth::user();
+
+        return ($baseDir ? $baseDir . '/' : '') . $user->getAuthIdentifier();
+    }
+}

--- a/src/Config/PathGenerator/UserPathGenerator.php
+++ b/src/Config/PathGenerator/UserPathGenerator.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Auth;
 
 class UserPathGenerator implements PathGenerator
 {
-    public function getPath(?string $baseDir): string
+    public function getPath(?string $baseDir = null): string
     {
         $user = Auth::user();
 

--- a/src/Config/PathGenerator/WordpressPathGenerator.php
+++ b/src/Config/PathGenerator/WordpressPathGenerator.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace FilamentCurator\Config\PathGenerator;
+
+use Carbon\Carbon;
+
+class WordpressPathGenerator implements PathGenerator
+{
+    public function getPath(?string $baseDir): string
+    {
+        $now = Carbon::now();
+
+        return ($baseDir ? $baseDir . '/' : '') . sprintf(
+            '%s/%s/%s/',
+            $now->format('Y'),
+            $now->format('m'),
+            $now->format('d')
+        );
+    }
+}

--- a/src/Config/PathGenerator/WordpressPathGenerator.php
+++ b/src/Config/PathGenerator/WordpressPathGenerator.php
@@ -11,7 +11,7 @@ class WordpressPathGenerator implements PathGenerator
         $now = Carbon::now();
 
         return ($baseDir ? $baseDir . '/' : '') . sprintf(
-            '%s/%s/%s/',
+            '%s/%s/%s',
             $now->format('Y'),
             $now->format('m'),
             $now->format('d')

--- a/src/CuratorThumbnails.php
+++ b/src/CuratorThumbnails.php
@@ -2,11 +2,11 @@
 
 namespace FilamentCurator;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Intervention\Image\Facades\Image;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Storage;
 
 class CuratorThumbnails
 {
@@ -75,7 +75,7 @@ class CuratorThumbnails
         if ($this->hasSizes($media->ext)) {
             $path_info = $this->getPathInfo($media->filename);
 
-            $thumbnails = collect(Storage::disk($media->disk)->allFiles())->filter(function($item) use ($path_info) {
+            $thumbnails = collect(Storage::disk($media->disk)->allFiles())->filter(function ($item) use ($path_info) {
                 return Str::startsWith($item, $path_info['dirname'] . '/' . $path_info['filename'] . '-');
             });
 

--- a/src/Forms/Components/CreateMediaForm.php
+++ b/src/Forms/Components/CreateMediaForm.php
@@ -2,12 +2,13 @@
 
 namespace FilamentCurator\Forms\Components;
 
-use Filament\Forms;
-use Livewire\Component;
+use FilamentCurator\Config\PathGenerator\PathGenerator;
 use FilamentCurator\Models\Media;
-use Filament\Forms\Contracts\HasForms;
+use Filament\Forms;
 use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
 use Filament\Pages\Actions\Concerns\CanSubmitForm;
+use Livewire\Component;
 
 class CreateMediaForm extends Component implements HasForms
 {
@@ -50,7 +51,6 @@ class CreateMediaForm extends Component implements HasForms
                 ->maxSize(config('filament-curator.max_size'))
                 ->rules(config('filament-curator.rules'))
                 ->acceptedFileTypes(config('filament-curator.accepted_file_types'))
-                ->directory(config('filament-curator.directory', 'images'))
                 ->disk(config('filament-curator.disk', 'public'))
                 ->visibility(config('filament-curator.visibility', 'public'))
                 ->required()

--- a/src/Forms/Components/MediaUpload.php
+++ b/src/Forms/Components/MediaUpload.php
@@ -2,20 +2,29 @@
 
 namespace FilamentCurator\Forms\Components;
 
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Livewire\TemporaryUploadedFile;
-use Intervention\Image\Facades\Image;
-use Illuminate\Support\Facades\Storage;
-use Filament\Forms\Components\FileUpload;
-use Filament\Forms\Components\BaseFileUpload;
+use FilamentCurator\Config\PathGenerator\PathGenerator;
 use FilamentCurator\Facades\CuratorThumbnails;
+use Filament\Forms\Components\BaseFileUpload;
+use Filament\Forms\Components\FileUpload;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Intervention\Image\Facades\Image;
+use Livewire\TemporaryUploadedFile;
 
 class MediaUpload extends FileUpload
 {
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->directory(function () {
+            $generator = config('filament-curator.path_generator');
+            if (class_exists($generator) && is_subclass_of($generator, PathGenerator::class)) {
+                return resolve($generator)->getPath(config('filament-curator.directory'));
+            }
+            return config('filament-curator.directory');
+        });
 
         $this->saveUploadedFileUsing(function (BaseFileUpload $component, TemporaryUploadedFile $file, $state, $set) {
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -2,12 +2,12 @@
 
 namespace FilamentCurator\Models;
 
-use stdClass;
-use Illuminate\Support\Arr;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Storage;
 use FilamentCurator\Facades\CuratorThumbnails;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Storage;
+use stdClass;
 
 class Media extends Model
 {
@@ -31,6 +31,10 @@ class Media extends Model
         static::deleted(function (Media $media) {
             CuratorThumbnails::destroy($media);
             Storage::disk($media->disk)->delete($media->filename);
+
+            if (count(Storage::disk($media->disk)->allFiles($media->directory)) == 0) {
+                Storage::disk($media->disk)->deleteDirectory($media->directory);
+            }
         });
     }
 

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -2,25 +2,25 @@
 
 namespace FilamentCurator\Resources;
 
-use Filament\Resources\Form;
-use Filament\Resources\Table;
-use Filament\Resources\Resource;
-use Filament\Forms\Components\View;
+use FilamentCurator\Forms\Components\MediaUpload;
+use FilamentCurator\Resources\MediaResource\Pages\CreateMedia;
+use FilamentCurator\Resources\MediaResource\Pages\EditMedia;
+use FilamentCurator\Resources\MediaResource\Pages\ListMedia;
+use FilamentCurator\Tables\Columns\ThumbnailColumn;
 use Filament\Forms\Components\Group;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Section;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\View;
+use Filament\Forms\Components\ViewField;
+use Filament\Resources\Form;
+use Filament\Resources\Resource;
+use Filament\Resources\Table;
+use Filament\Tables\Actions\DeleteAction;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\ViewField;
-use Filament\Tables\Actions\DeleteAction;
-use Filament\Forms\Components\Placeholder;
-use FilamentCurator\Forms\Components\MediaUpload;
-use FilamentCurator\Tables\Columns\ThumbnailColumn;
-use FilamentCurator\Resources\MediaResource\Pages\EditMedia;
-use FilamentCurator\Resources\MediaResource\Pages\ListMedia;
-use FilamentCurator\Resources\MediaResource\Pages\CreateMedia;
 
 class MediaResource extends Resource
 {
@@ -49,7 +49,6 @@ class MediaResource extends Resource
                                     ->disableLabel()
                                     ->maxWidth(5000)
                                     ->acceptedFileTypes(config('filament-curator.accepted_file_types'))
-                                    ->directory(config('filament-curator.directory', 'images'))
                                     ->disk(config('filament-curator.disk', 'public'))
                                     ->required()
                                     ->maxFiles(1)
@@ -116,7 +115,7 @@ class MediaResource extends Resource
                                 Textarea::make('description')
                                     ->label(__('filament-curator::media-form.labels.description'))
                                     ->rows(2),
-                                ])
+                            ])
                     ])->columnSpan([
                         'lg' => 'full',
                         'xl' => 1,
@@ -131,8 +130,8 @@ class MediaResource extends Resource
         return $table
             ->columns([
                 ThumbnailColumn::make('thumbnail_url')
-					->label(__('filament-curator::resource.labels.thumbnail_url'))
-					->size(40),
+                    ->label(__('filament-curator::resource.labels.thumbnail_url'))
+                    ->size(40),
                 TextColumn::make('public_id')
                     ->label(__('filament-curator::resource.labels.public_id'))
                     ->searchable()

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -66,7 +66,7 @@ class MediaResource extends Resource
                                         $component->state($record);
                                     }),
                             ]),
-                        Section::make('Details')
+                        Section::make(__('filament-curator::resource.labels.details'))
                             ->schema([
                                 Placeholder::make('uploaded_on')
                                     ->label(__('filament-curator::resource.labels.uploaded_on'))

--- a/src/Resources/MediaResource/Pages/EditMedia.php
+++ b/src/Resources/MediaResource/Pages/EditMedia.php
@@ -14,8 +14,8 @@ class EditMedia extends EditRecord
     public function getActions(): array
     {
         return [
-            Action::make('save')->action('save'),
-            Action::make('preview')->color('secondary')->url($this->record->url)->openUrlInNewTab(),
+            Action::make('save')->action('save')->label(__('filament-curator::resource.labels.save')),
+            Action::make('preview')->color('secondary')->url($this->record->url)->openUrlInNewTab()->label(__('filament-curator::resource.labels.preview')),
             DeleteAction::make(),
         ];
     }


### PR DESCRIPTION
It's possible to define a path generator in config, a simple class that inherits from PathGenerator interface that returns the directory used to store the media file and thumbnails inside the configured disk. The directory can be dynamic and based on other system parameters like the current date, the current user, or other configurations.
There are two example generators: DatePathGenerator and UserPathGenerator.
Note: we do not have the Media model at the time of storing the file, so we can't use its attributes to define the directory.