### PR TITLE
Remove leftover ray call

### DIFF
--- a/src/View/Components/Glider.php
+++ b/src/View/Components/Glider.php
@@ -115,7 +115,6 @@ class Glider extends Component
         }
 
         return function (array $data) {
-            ray($data);
             return 'curator::components.glider';
         };
     }


### PR DESCRIPTION
Exception caused when using the <x-curator-glider /> blade component. Since I do not have `spatie/ray` installed it threw an exception that the function doesn't exist.

I've removed the call as I don't believe it should be in there anyway in production, but I do find it odd that my local setup didn't at least have it loaded (since it's a dev dependency) - though I haven't really looked into why.