### PR TITLE
Image exif trap malformed utf-8 characters

### DIFF
--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -134,6 +134,15 @@ class CuratorPanel extends Component implements HasForms
         $media = [];
 
         foreach ($this->addMediaForm->getState()['files'] as $item) {
+            // Fix malformed utf-8 characters
+            if (!empty($item['exif'])) {
+                array_walk_recursive($item['exif'], function(&$entry){
+                    if(!mb_detect_encoding($entry, 'utf-8', true)){
+                        $entry = utf8_encode($entry);
+                    }
+                });
+            }
+
             $media[] = Media::create($item);
         }
 


### PR DESCRIPTION
Laravel throws exception if image upload contains invalid data. 

Tested with: https://github.com/ianare/exif-samples/blob/master/jpg/Reconyx_HC500_Hyperfire.jpg

> Unable to encode attribute [exif] for model [Awcodes\Curator\Models\Media] to JSON: Malformed UTF-8 characters, possibly incorrectly encoded. 