### PR TITLE
Fixes resource navigation naming and list title naming

### DIFF
--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -32,7 +32,7 @@ class MediaResource extends Resource
 
     public static function getNavigationLabel(): string
     {
-        return static::getModelLabel();
+        return Str::of(static::getPluralModelLabel())->title() ?? Str::of(static::getModelLabel())->title();
     }
 
     protected static function getNavigationIcon(): string

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -32,7 +32,7 @@ class MediaResource extends Resource
 
     public static function getNavigationLabel(): string
     {
-        return Str::of(static::getPluralModelLabel())->title() ?? Str::of(static::getModelLabel())->title();
+        return Str::title(static::getPluralModelLabel()) ?? Str::title(static::getModelLabel());
     }
 
     protected static function getNavigationIcon(): string
@@ -80,7 +80,7 @@ class MediaResource extends Resource
                                             }),
                                     ]),
                                 Forms\Components\Tabs\Tab::make(__('curator::forms.sections.curation'))
-                                    ->visible(fn($record) => Str::of($record->type)->contains('image'))
+                                    ->visible(fn ($record) => Str::of($record->type)->contains('image'))
                                     ->schema([
                                         Forms\Components\Repeater::make('curations')
                                             ->label(__('curator::forms.sections.curation'))
@@ -114,7 +114,7 @@ class MediaResource extends Resource
                             ]),
                         Forms\Components\Section::make(__('curator::forms.sections.exif'))
                             ->collapsed()
-                            ->visible(fn($record) => $record && $record->exif)
+                            ->visible(fn ($record) => $record && $record->exif)
                             ->schema([
                                 Forms\Components\KeyValue::make('exif')
                                     ->disableLabel()

--- a/src/Resources/MediaResource/ListMedia.php
+++ b/src/Resources/MediaResource/ListMedia.php
@@ -8,6 +8,7 @@ use Filament\Pages\Actions\Action;
 use Filament\Resources\Pages\ListRecords;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Str;
 
 class ListMedia extends ListRecords
 {
@@ -15,7 +16,7 @@ class ListMedia extends ListRecords
 
     protected function getTitle(): string
     {
-        return app('curator')->getResourceLabel();
+        return Str::of(app('curator')->getResourceLabel())->title();
     }
 
     protected function getActions(): array
@@ -30,7 +31,7 @@ class ListMedia extends ListRecords
                     ->icon(function (): string {
                         return Session::get('tableLayout') ? 'heroicon-s-view-list' : 'heroicon-s-view-grid';
                     })
-                    ->action(function(): void {
+                    ->action(function (): void {
                         Session::put('tableLayout', ! Session::get('tableLayout'));
                     }),
             ],

--- a/src/Resources/MediaResource/ListMedia.php
+++ b/src/Resources/MediaResource/ListMedia.php
@@ -16,7 +16,7 @@ class ListMedia extends ListRecords
 
     protected function getTitle(): string
     {
-        return Str::of(app('curator')->getResourceLabel())->title();
+        return Str::headline(app('curator')->getPluralResourceLabel());
     }
 
     protected function getActions(): array


### PR DESCRIPTION
This PR fixes a formatting issue introduced with PR #103. This PR will:

1. For the navigation menu it will use the `pluralResourceLabel()` if set or fallback to the `resourceLabel()` if not set.
2. Apply `Str::title()` to `getNavigationLabel()` as Filament core does.
3. Apply `Str::headline() to the `getTitle()` as Filament core does.

## Additional information
Before #103, the Navigation label, Title label, and model label were all independent of each other. This was more clearly evident when changing the resource name to something that had a different plural name, such as "Image". Before #103, you could set `resourceLabel('image')` and `pluralResourceLabel('images')` and the Navigation label would be "Images", the Title label would be "Image" and the model label (ie, the button label) would be "New image" (notice the upper and lower cases). Filament core keeps the model label in the button lower case.

With #103, there is no way to recreate this. Setting `resourceLabel('image')` makes the button lowercase, but also the navigation and title become lowercase. Making it `resourceLabel('Image')` makes the button uppercase (which doesn't follow Filament conventions). Setting the `pluralResourceLabel('images')`, doesn't affect the navigation at all, just the breadcomes.

This PR brings this back. 

Another option could be to implement a `NavigationLabel()`, so that you can set the Navigation label indepdentenly from the `PluralLabel()`, but usually those are the same. 

Before #103
<img width="1086" alt="Screenshot 2023-02-12 at 12 55 58 AM" src="https://user-images.githubusercontent.com/6097099/218297464-c361e52e-6dc0-403a-9740-ba06a525f66e.png">


After #103
<img width="1020" alt="Screenshot 2023-02-12 at 12 41 44 AM" src="https://user-images.githubusercontent.com/6097099/218297051-821465c9-d8ea-4a1b-8dde-23d4eed99923.png">


