### PR TITLE
Upload required on create

### DIFF
--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -69,6 +69,7 @@ class MediaResource extends Resource
                             ->hiddenOn('edit')
                             ->schema([
                                 static::getUploaderField()
+                                    ->required()
                             ]),
                         Forms\Components\Tabs::make('image')
                             ->hiddenOn('create')


### PR DESCRIPTION
Fixes mysql error Field 'name' doesn't have a default value if you save without upload