### PR TITLE
Use contain instead of fit

### DIFF
--- a/resources/views/components/forms/picker.blade.php
+++ b/resources/views/components/forms/picker.blade.php
@@ -41,7 +41,7 @@
                         alt="{{ $currentItem['alt'] }}"
                          @class([
                             'h-full',
-                            'object-fit' => $isConstrained(),
+                            'object-contain' => $isConstrained(),
                             'object-cover w-full' => ! $isConstrained(),
                         ])
                     />


### PR DESCRIPTION
I thought I already PR'ed this but seems like not. This PR changes the `constrain` option css `object-contain`, which resizes the content to fit entirely within its container while maintaining its aspect ratio.