### PR TITLE
fix: Can't make an image with S3 drive

### DIFF
--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -29,7 +29,8 @@ class Uploader extends FileUpload
             $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
 
             if (Curator::isResizable($extension)) {
-                $image = Image::make($file->getRealPath());
+                $content = Storage::disk($file->disk)->get($file->path());
+                $image = Image::make($content);
                 $image->orientate();
                 $width = $image->getWidth();
                 $height = $image->getHeight();


### PR DESCRIPTION
Like I said in the issue: [#152](https://github.com/awcodes/filament-curator/issues/152)
Image::make only works with local drives, not S3 - it gives an error "Image source not readable."
It makes sense to add a disk type here.