### PR TITLE
Check for empty state before querying database

### DIFF
--- a/src/Components/Forms/CuratorPicker.php
+++ b/src/Components/Forms/CuratorPicker.php
@@ -168,6 +168,10 @@ class CuratorPicker extends Field
 
     public function getCurrentItem(): Model|Collection|null
     {
+        if (! filled($this->getState())) {
+            return null;
+        }
+
         return Curator::getMediaModel()::where('id', $this->getState())->first();
     }
 


### PR DESCRIPTION
Small performance improvement to prevent empty null query
```sql
select * from `media` where `id` is null limit 1
```