### PR TITLE
Fix non-resizable media

### DIFF
--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -56,6 +56,12 @@ class MediaController extends Controller
             abort(404);
         }
 
+        $media = Curator::getMediaModel()::where('path', $path)->first();
+
+        if (! Curator::isResizable($media->ext)) {
+            return Storage::disk($media->disk)->response($media->path);
+        }
+
         $server = app('curator')->getGlideServer();
         $server->setBaseUrl('/curator/');
         return $server->getImageResponse($path, request()->all());


### PR DESCRIPTION
Fixes error with uploaded svg files:
> Unsupported image type image/svg+xml. GD driver is only able to decode JPG, PNG, GIF, BMP or WebP files