### PR TITLE
Fix: Allow dynamic model resources when using picker

### DIFF
--- a/resources/views/components/forms/picker.blade.php
+++ b/resources/views/components/forms/picker.blade.php
@@ -76,7 +76,7 @@
                     </button>
                     @if (! $isDisabled())
                     <a
-                        href="{{ \Awcodes\Curator\Resources\MediaResource::getUrl('edit', $currentItem['id']) }}"
+                        href="{{ call_user_func([\Filament\Facades\Filament::getModelResource(\Awcodes\Curator\Facades\Curator::getMediaModel()), 'getUrl'], 'edit', $currentItem['id']) }}"
                         target="_blank"
                         rel="noopener nofollow"
                         class="flex items-center justify-center flex-none w-10 h-10 transition text-success-600 hover:text-success-500 dark:text-success-500 dark:hover:text-success-400"


### PR DESCRIPTION
The problem occurs when a custom MediaResource is used.
The [CuratorPicker](https://github.com/awcodes/filament-curator/blob/2.x/src/Components/Forms/CuratorPicker.php) form field uses a static method to retrieve the edit url for a selected media, which could be called dynamically from the registered resource for the used media model.