### PR TITLE
Add missing properties to CuratorPicker

### DIFF
--- a/src/Components/Forms/CuratorPicker.php
+++ b/src/Components/Forms/CuratorPicker.php
@@ -33,6 +33,8 @@ class CuratorPicker extends Field
 
     protected bool|Closure|null $isConstrained = false;
 
+    protected bool|Closure|null $isMultiple = false;
+
     protected string|Closure|null $curatorDiskName = null;
 
     protected string|Closure|null $curatorDirectory = null;
@@ -54,6 +56,10 @@ class CuratorPicker extends Field
     protected string|Closure|null $curatorImageResizeTargetHeight = null;
 
     protected string|Closure|null $curatorImageResizeTargetWidth = null;
+
+    protected string|Closure|null $relationshipTitleColumnName = null;
+
+    protected string|Closure|null $relationship = null;
 
     /**
      * @throws Exception


### PR DESCRIPTION
PHP8.2 throwing error on save:
> Undefined property: Awcodes\Curator\Components\Forms\CuratorPicker::$isMultiple