### PR TITLE
Fix empty array offset

### DIFF
--- a/src/Components/Forms/CuratorPicker.php
+++ b/src/Components/Forms/CuratorPicker.php
@@ -352,6 +352,10 @@ class CuratorPicker extends Field
         });
 
         $this->saveRelationshipsUsing(static function (CuratorPicker $component, Model $record, $state) {
+            if (blank($state)) {
+                return;
+            }
+
             if ($component->isMultiple()) {
                 $state = Arr::pluck($state,'id');
                 $component->getRelationship()->sync($state ?? []);


### PR DESCRIPTION
Fixes error when you don't select media and `$state is null `Arr::first($state)['id'])`
> Trying to access array offset on value of type null