### PR TITLE
Fix CuratorColumn image size with px

### DIFF
--- a/resources/views/components/tables/curator-column.blade.php
+++ b/resources/views/components/tables/curator-column.blade.php
@@ -43,8 +43,8 @@
         >
             @if (app('curator')->isResizable($item->ext))
                 @php
-                    $img_width = $width ? str_replace('px', '', $width) : $width;
-                    $img_height = $height ? str_replace('px', '', $height) : $height;
+                    $img_width = $width ? (int)$width : null;
+                    $img_height = $height ? (int)$height : null;
 
                     if ($resolution) {
                         $img_width *= $resolution;

--- a/resources/views/components/tables/curator-column.blade.php
+++ b/resources/views/components/tables/curator-column.blade.php
@@ -56,6 +56,7 @@
                     "
                     @class([
                         'h-full w-auto' => str($item->type)->contains('svg'),
+                        'max-w-none' => $height && ! $width,
                         'object-cover object-center' => ! str($item->type)->contains('svg') && ($isRounded() || $width || $height)
                     ])
                     {{ $getExtraImgAttributeBag() }}

--- a/resources/views/components/tables/curator-column.blade.php
+++ b/resources/views/components/tables/curator-column.blade.php
@@ -17,6 +17,11 @@
         4 => '-space-x-4',
         default => '-space-x-1',
     };
+
+    $resolution = $getResolution();
+
+    $height = $getHeight();
+    $width = $getWidth() ?? ($isRounded() ? $height : null);
 @endphp
 
 <div
@@ -25,11 +30,6 @@
         $overlap . ' flex items-center' => $imageCount > 1,
     ]) }}
 >
-    @php
-        $height = $getHeight();
-        $width = $getWidth() ?? ($isRounded() ? $height : null);
-    @endphp
-
     @if ($items)
         @foreach ($items as $item)
         <div style="
@@ -42,10 +42,19 @@
             ])
         >
             @if (app('curator')->isResizable($item->ext))
+                @php
+                    $img_width = $width ? str_replace('px', '', $width) : $width;
+                    $img_height = $height ? str_replace('px', '', $height) : $height;
+
+                    if ($resolution) {
+                        $img_width *= $resolution;
+                        $img_height *= $resolution;
+                    }
+                @endphp
                 <img
                     src="{{ $item->getSignedUrl([
-                        'w' => $width ? str_replace('px', '', $width) : $width,
-                        'h' => $height ? str_replace('px', '', $height) : $height,
+                        'w' => $img_width,
+                        'h' => $img_height,
                         'fit' => 'crop',
                         'fm' => 'webp'
                     ]) }}"

--- a/resources/views/components/tables/curator-column.blade.php
+++ b/resources/views/components/tables/curator-column.blade.php
@@ -43,7 +43,12 @@
         >
             @if (app('curator')->isResizable($item->ext))
                 <img
-                    src="{{ $item->getSignedUrl(['w' => $width, 'h' => $height, 'fit' => 'crop', 'fm' => 'webp']) }}"
+                    src="{{ $item->getSignedUrl([
+                        'w' => $width ? str_replace('px', '', $width) : $width,
+                        'h' => $height ? str_replace('px', '', $height) : $height,
+                        'fit' => 'crop',
+                        'fm' => 'webp'
+                    ]) }}"
                     alt="{{ $item->alt }}"
                     style="
                         {!! $height !== null ? "height: {$height};" : null !!}

--- a/src/Components/Tables/CuratorColumn.php
+++ b/src/Components/Tables/CuratorColumn.php
@@ -20,6 +20,8 @@ class CuratorColumn extends ImageColumn
 
     protected int|Closure|null $ring = null;
 
+    protected int|Closure|null $resolution = null;
+
     public function limit(int | Closure | null $limit = 3): static
     {
         $this->limit = $limit;
@@ -30,6 +32,13 @@ class CuratorColumn extends ImageColumn
     public function overlap(int | Closure | null $overlap): static
     {
         $this->overlap = $overlap;
+
+        return $this;
+    }
+
+    public function resolution(int | Closure | null $resolution): static
+    {
+        $this->resolution = $resolution;
 
         return $this;
     }
@@ -93,6 +102,11 @@ class CuratorColumn extends ImageColumn
     public function getOverlap(): ?int
     {
         return $this->evaluate($this->overlap);
+    }
+
+    public function getResolution(): ?int
+    {
+        return $this->evaluate($this->resolution);
     }
 
     public function getRing(): ?int


### PR DESCRIPTION
Fixes https://github.com/awcodes/filament-curator/issues/210

Also adds `resolution` to allow the resized image to be upscaled for HD quality. 
```php
CuratorColumn::make()
  ->size(100)
  ->resolution(2);
```