### PR TITLE
fixes visiblity issue on s3 storage

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -37,14 +37,23 @@ class Media extends Model
     {
         return Attribute::make(
             get: function () {
-                if (Storage::disk($this->disk)->exists($this->path) && Storage::disk($this->disk)->getVisibility($this->path) === 'private') {
-                    return Storage::disk($this->disk)->temporaryUrl(
-                        $this->path,
-                        now()->addMinutes(5)
-                    );
+
+                if(Storage::disk($this->disk)->exists($this->path) === false){
+                    return null;
                 }
 
-                return Storage::disk($this->disk)->url($this->path);
+                try {
+                    $isPrivate = Storage::disk($this->disk)->getVisibility($this->path) === 'private';
+                }catch(\Throwable){
+                    // ACL not supported on Storage Bucket, Laravel only throws exception here so need to be careful.
+                    // so we assume it's private
+                    $isPrivate = true;
+                }
+
+                return $isPrivate ? Storage::disk($this->disk)->temporaryUrl(
+                        $this->path,
+                        now()->addMinutes(5)
+                    ) : Storage::disk($this->disk)->url($this->path);
             },
         );
     }


### PR DESCRIPTION
When using S3 in a locked style (without access to ACL's) - media pages do not work,
added check to work where this is the case.