### PR TITLE
Add condition to check panel exists for routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -4,12 +4,16 @@ use Awcodes\Curator\Http\Controllers\MediaController;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Route;
 
-Route::domain(Filament::getCurrentPanel()->getDomain())
-    ->middleware(Filament::getCurrentPanel()->getMiddleware())
-    ->group(function () {
-        Route::get('/curator/media', [MediaController::class, 'index']);
-        Route::get('/curator/media/search', [MediaController::class, 'search']);
-    });
+$panel = Filament::getCurrentPanel();
+
+if ($panel) {
+    Route::domain($panel->getDomain())
+        ->middleware($panel->getMiddleware())
+        ->group(function () {
+            Route::get('/curator/media', [MediaController::class, 'index']);
+            Route::get('/curator/media/search', [MediaController::class, 'search']);
+        });
+}
 
 Route::get('/curator/{path}', [MediaController::class, 'show'])
     ->where('path', '.*');


### PR DESCRIPTION
Fix error when running `testbench` directly outside of a standard project setup. 
> Call to a member function getDomain() on null
