### PR TITLE
[3.x] ✨ Add an optional count badge to navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ public function panel(Panel $panel): Panel
                 ->navigationIcon('heroicon-o-photo')
                 ->navigationGroup('Content')
                 ->navigationSort(3)
+                ->navigationCountBadge()
                 ->resource(\App\Filament\Resources\CustomMediaResource::class)
         ]);
 }

--- a/config/curator.php
+++ b/config/curator.php
@@ -37,6 +37,7 @@ return [
         'navigation_group' => null,
         'navigation_icon' => 'heroicon-o-photo',
         'navigation_sort' => null,
+        'navigation_count_badge' => false,
         'resource' => \Awcodes\Curator\Resources\MediaResource::class,
     ],
     'should_preserve_filenames' => false,

--- a/src/CuratorPlugin.php
+++ b/src/CuratorPlugin.php
@@ -19,6 +19,8 @@ class CuratorPlugin implements Plugin
 
     protected ?int $navigationSort = null;
 
+    protected ?bool $navigationCountBadge = null;
+
     protected string | Closure | null $pluralLabel = null;
 
     protected ?string $resource = null;
@@ -81,6 +83,11 @@ class CuratorPlugin implements Plugin
         return $this->navigationSort ?? config('curator.resources.navigation_sort');
     }
 
+    public function getNavigationCountBadge(): ?bool
+    {
+        return $this->navigationCountBadge ?? config('curator.resources.navigation_count_badge');
+    }
+
     public function navigationGroup(string $group = null): static
     {
         $this->navigationGroup = $group;
@@ -98,6 +105,13 @@ class CuratorPlugin implements Plugin
     public function navigationSort(int $order): static
     {
         $this->navigationSort = $order;
+
+        return $this;
+    }
+
+    public function navigationCountBadge(bool $show = true): static
+    {
+        $this->navigationCountBadge = $show;
 
         return $this;
     }

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -52,6 +52,12 @@ class MediaResource extends Resource
         return CuratorPlugin::get()->getNavigationGroup();
     }
 
+    public static function getNavigationBadge(): ?string
+    {
+        return CuratorPlugin::get()->getNavigationCountBadge() ?
+            number_format(static::getModel()::count()) : null;
+    }
+
     public static function form(Form $form): Form
     {
         return $form


### PR DESCRIPTION
This adds an optional badge containing the total media count to the resource navigation item.

```php
$panel->navigationCountBadge()
```

![Screenshot](https://i.imgur.com/JkTjbep.png)