### PR TITLE
Fix missing css and load JS on request

### DIFF
--- a/src/CuratorServiceProvider.php
+++ b/src/CuratorServiceProvider.php
@@ -48,8 +48,8 @@ class CuratorServiceProvider extends PackageServiceProvider
         Blade::component('curator-curation', View\Components\Curation::class);
 
         FilamentAsset::register([
-            AlpineComponent::make('curation', __DIR__ . '/../resources/dist/curation.js'),
-            Css::make('curator', __DIR__ . '/../resources/dist/curator.css')->loadedOnRequest(),
+            AlpineComponent::make('curation', __DIR__ . '/../resources/dist/curation.js')->loadedOnRequest(),
+            Css::make('curator', __DIR__ . '/../resources/dist/curator.css'),
         ], 'awcodes/curator');
     }
 }


### PR DESCRIPTION
Lazy loading was being added to the CSS when it's the JS which's lazy loaded:

https://github.com/awcodes/filament-curator/blob/5d8daba5cee1dd458294f43d60005876a55c8acc/resources/views/components/modals/curator-curation.blade.php#L8