### PR TITLE
Don't query Media if null

### DIFF
--- a/src/View/Components/Glider.php
+++ b/src/View/Components/Glider.php
@@ -50,7 +50,9 @@ class Glider extends Component
         public ?string $fallback = null,
     ) {
         if (! $media instanceof Media) {
-            $this->media = app(Media::class)::where('id', $media)->first();
+            if (is_int($media)) {
+                $this->media = app(Media::class)::where('id', $media)->first();
+            }
 
             if (! $this->media && $this->fallback) {
                 $this->media = (object) $this->getGliderFallback($this->fallback);

--- a/src/View/Components/Glider.php
+++ b/src/View/Components/Glider.php
@@ -50,7 +50,7 @@ class Glider extends Component
         public ?string $fallback = null,
     ) {
         if (! $media instanceof Media) {
-            if (is_int($media)) {
+            if(! is_null($media)) {
                 $this->media = app(Media::class)::where('id', $media)->first();
             }
 


### PR DESCRIPTION
Every time we pass `null` to a glider component a query is fired to see if a Media record exists. 

It would be better to use the fallback (if defined) right away when `$media` is not integer.