### PR TITLE
Fix: disabled curations for SVG files

### DIFF
--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -83,7 +83,7 @@ class MediaResource extends Resource
                                             }),
                                     ]),
                                 Forms\Components\Tabs\Tab::make(__('curator::forms.sections.curation'))
-                                    ->visible(fn ($record) => Str::of($record->type)->contains('image'))
+                                    ->visible(fn ($record) => Str::of($record->type)->contains('image') && ! Str::of($record->type)->contains('svg'))
                                     ->schema([
                                         Forms\Components\Repeater::make('curations')
                                             ->label(__('curator::forms.sections.curation'))

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -83,7 +83,7 @@ class MediaResource extends Resource
                                             }),
                                     ]),
                                 Forms\Components\Tabs\Tab::make(__('curator::forms.sections.curation'))
-                                    ->visible(fn ($record) => Str::of($record->type)->contains('image') && ! Str::of($record->type)->contains('svg'))
+                                    ->visible(fn ($record) => Curator::isResizable($record->ext))
                                     ->schema([
                                         Forms\Components\Repeater::make('curations')
                                             ->label(__('curator::forms.sections.curation'))


### PR DESCRIPTION
Visibility of curations tab was only depending on file type containing `image` but should not be enabled for `image/svg+xml` file types.