### PR TITLE
feature: Preserve original file name in media title

### DIFF
--- a/resources/views/components/forms/picker.blade.php
+++ b/resources/views/components/forms/picker.blade.php
@@ -178,7 +178,7 @@
                             class="absolute inset-x-0 bottom-0 flex items-center justify-between gap-3 bg-gradient-to-t from-black/80 to-transparent px-2 pb-1 pt-10 text-xs text-white"
                         >
                             <p class="truncate">
-                                {{ $item["name"] }}.{{ $item["ext"] }}
+                                {{ $item["prettyName"] }}
                             </p>
                             <p class="flex-shrink-0">
                                 {{ $item["size_for_humans"] }}

--- a/resources/views/components/modals/curator-panel.blade.php
+++ b/resources/views/components/modals/curator-panel.blade.php
@@ -68,7 +68,7 @@
                             </template>
                         </button>
 
-                        <p x-text="file.name" class="text-xs truncate absolute bottom-0 inset-x-0 px-1 pb-1 pt-4 text-white bg-gradient-to-t from-black/80 to-transparent pointer-events-none"></p>
+                        <p x-text="file.prettyName" class="text-xs truncate absolute bottom-0 inset-x-0 px-1 pb-1 pt-4 text-white bg-gradient-to-t from-black/80 to-transparent pointer-events-none"></p>
 
                         <button
                             type="button"

--- a/resources/views/components/tables/grid-column.blade.php
+++ b/resources/views/components/tables/grid-column.blade.php
@@ -26,7 +26,7 @@
         <div
             class="absolute inset-x-0 bottom-0 flex items-center justify-between px-1.5 pt-10 pb-1.5 text-xs text-white bg-gradient-to-t from-black/80 to-transparent gap-3"
         >
-            <p class="truncate">{{ $record->title ?? $record->name . '.' . $record->ext }}</p>
+            <p class="truncate">{{ $record->getPrettyName() }}</p>
             <p class="flex-shrink-0">{{ $record->size_for_humans }}</p>
         </div>
     </div>

--- a/src/Components/Forms/CuratorPicker.php
+++ b/src/Components/Forms/CuratorPicker.php
@@ -6,6 +6,7 @@ use Awcodes\Curator\Actions\DownloadAction;
 use Awcodes\Curator\Actions\PickerAction;
 use Awcodes\Curator\Facades\Curator;
 use Awcodes\Curator\Generators\PathGenerator;
+use Awcodes\Curator\Models\Media;
 use Closure;
 use Exception;
 use Filament\Forms\Components\Component;
@@ -102,6 +103,10 @@ class CuratorPicker extends Field
             }
 
             foreach ($media as $itemData) {
+                if ($itemData instanceof Media) {
+                    $itemData->loadPrettyName();
+                }
+
                 $items[(string)Str::uuid()] = $itemData;
             }
 
@@ -431,6 +436,7 @@ class CuratorPicker extends Field
 
             if ($component->isMultiple()) {
                 $relatedModels = $relationship->getResults();
+                $relatedModels->each->loadPrettyName();
 
                 $component->state($relatedModels);
 
@@ -443,6 +449,8 @@ class CuratorPicker extends Field
             if (!$relatedModel) {
                 return;
             }
+
+            $relatedModel->loadPrettyName();
 
             $component->state(
                 $relatedModel->getAttribute(

--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -76,6 +76,8 @@ class Uploader extends FileUpload
                 'file' => $file,
             ]);
 
+            $this->storeFileName($storedFile['path'], $file->getClientOriginalName());
+
             $file->delete();
 
             return $storedFile;

--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -3,6 +3,7 @@
 namespace Awcodes\Curator\Http\Controllers;
 
 use Awcodes\Curator\Facades\Curator;
+use Awcodes\Curator\Models\Media;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\Storage;
@@ -46,6 +47,8 @@ class MediaController extends Controller
                 });
         }
 
+        $files->getCollection()->each->loadPrettyName();
+
         return response()->json($files);
     }
 
@@ -62,6 +65,8 @@ class MediaController extends Controller
                     ->orWhere('description', 'like', '%'.$request->query('q').'%');
             })
             ->paginate(50);
+
+        $files->getCollection()->each->loadPrettyName();
 
         return response()->json($files);
     }

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -131,4 +131,18 @@ class Media extends Model
             return $item['curation']['key'] === $key;
         }));
     }
+
+    public function loadPrettyName(): void
+    {
+        $this->attributes['prettyName'] = $this->getPrettyName();
+    }
+
+    public function getPrettyName(): string
+    {
+        if (filled($this->title)) {
+            return $this->title;
+        }
+
+        return $this->name . '.' . $this->ext;
+    }
 }

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -272,6 +272,7 @@ class MediaResource extends Resource
             ->pathGenerator(app('curator')->getPathGenerator())
             ->visibility(app('curator')->getVisibility())
             ->maxFiles(1)
-            ->panelAspectRatio('24:9');
+            ->panelAspectRatio('24:9')
+            ->storeFileNamesIn('originalFilename');
     }
 }

--- a/src/Resources/MediaResource/CreateMedia.php
+++ b/src/Resources/MediaResource/CreateMedia.php
@@ -8,4 +8,15 @@ use Filament\Resources\Pages\CreateRecord;
 class CreateMedia extends CreateRecord
 {
     protected static string $resource = MediaResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        if (blank($data['title'])) {
+            $data['title'] = pathinfo($data['originalFilename'], PATHINFO_FILENAME);
+        }
+
+        unset($data['originalFilename']);
+
+        return $data;
+    }
 }


### PR DESCRIPTION
The original file name preservation behaviour is kept, but the title is now autofilled with the name of the uploaded file if a different title is not provided. Also, I've made the displaying of file names/titles more consistent by introducing a "pretty name" attribute to the Media model.