### PR TITLE
Fix: `time()` being appended regardless of pre-existing file with same filename

### DIFF
--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -91,7 +91,7 @@ class Uploader extends FileUpload
 
             $filename = $component->shouldPreserveFilenames()
                 ? Str::of(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))->slug()
-                : Str::uuid();
+                : (string)Str::uuid();
 
             $extension = $file->getClientOriginalExtension();
 
@@ -117,7 +117,7 @@ class Uploader extends FileUpload
                 $exif = $image->exif();
             }
 
-            if ($file->exists()) {
+            if (Storage::disk($component->getDiskName())->exists(ltrim($component->getDirectory().'/'.$filename.'.'.$extension, '/'))) {
                 $filename = $filename . '-' . time();
             }
 


### PR DESCRIPTION
## Problem
It seems that regardless of a file existing or not, `time()` is appended to the filename, which it appears should only occur when the file does in fact exist.

## Solution
- Copy over the way this conditional was handled in v2
- Convert `$filename` to a string for cases where it is equal to the return of `Str::uuid()`, to avoid Livewire throwing an exception about an invalid component property type if it does not have `time()` concatenated to it (effectively converting it to a string).

## Testing
- Tested both local and S3 storage disk types with adding duplicates, with `should_preserve_filenames = true`
- Tested both local and S3 storage disk types with adding duplicates, with `should_preserve_filenames = false`
