### PR TITLE
Fix: Store original filename as title in MultiUploadAction

### DIFF
--- a/src/Actions/MultiUploadAction.php
+++ b/src/Actions/MultiUploadAction.php
@@ -49,7 +49,7 @@ class MultiUploadAction extends Action
                         });
                     }
 
-                    $item['title'] = pathinfo($data['originalFilenames'][$item['path']] ?? null, PATHINFO_FILENAME);
+                    $item['title'] = pathinfo($data['originalFilename'][$item['path']] ?? null, PATHINFO_FILENAME);
 
                     tap(
                         App::make(Media::class)->create($item),


### PR DESCRIPTION
Hi @awcodes — and thank you very much for all your work on this plugin, it's much appreciated!

I think this may be a small typo in the action? Changing this results in the filename being set as the title: which would be exactly what i'd expect. 