### PR TITLE
Flush glide-cache in model-observer if images are replaced

### DIFF
--- a/src/Observers/MediaObserver.php
+++ b/src/Observers/MediaObserver.php
@@ -58,6 +58,10 @@ class MediaObserver
 
             $media->name = $media->getOriginal()['name'];
             $media->path = $media->directory . '/' . $media->getOriginal()['name'] . '.' . $media->ext;
+
+            // Delete glide-cache for replaced image
+            $server = app(config('curator.glide.server'))->getFactory();
+            $server->deleteCache($media->path);
         }
 
         // Rename file name


### PR DESCRIPTION
If images are replaced in media-resource the glide-cache should be flushed otherwise the images in list-view are not updated.