### PR TITLE
Feat: force option for glider component

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Glide's options.
 - srcset: this will output the necessary srcset with glide generated urls.
   Must be an array of srcset widths and requires the 'sizes' attribute to
   also be set.
+- force: (bool) this can be used to force glider to return a signed url and is helpful when returning urls from cloud disks. This should be used with the knowledge that it could have performance implications.
 
 ```blade
 <div class="aspect-video w-64">

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -127,14 +127,16 @@ class Media extends Model
         return round($size, $precision) . ' ' . $units[$i];
     }
 
-    public function getSignedUrl(array $params = []): string
+    public function getSignedUrl(array $params = [], bool $force = false): string
     {
-        if (
-            !$this->resizable ||
-            in_array($this->disk, config('curator.cloud_disks')) ||
-            !Storage::disk($this->disk)->exists($this->path)
-        ) {
-            return $this->url;
+        if (! $force) {
+            if (
+                ! $this->resizable ||
+                in_array($this->disk, config('curator.cloud_disks')) ||
+                ! Storage::disk($this->disk)->exists($this->path)
+            ) {
+                return $this->url;
+            }
         }
 
         $urlBuilder = UrlBuilderFactory::create('/curator/', config('app.key'));

--- a/src/View/Components/Glider.php
+++ b/src/View/Components/Glider.php
@@ -48,9 +48,10 @@ class Glider extends Component
         public ?string $watermarkPosition = null,
         public ?string $watermarkAlpha = null,
         public ?string $fallback = null,
+        public bool $force = false,
     ) {
         if (! $media instanceof Media) {
-            if(! is_null($media)) {
+            if (! is_null($media)) {
                 $this->media = app(Media::class)::where('id', $media)->first();
             }
 
@@ -105,7 +106,7 @@ class Glider extends Component
                 return $urlBuilder->getUrl($this->media->path, $params);
             }
 
-            return $this->media->getSignedUrl($params);
+            return $this->media->getSignedUrl($params, $this->force);
         }
 
         return '';


### PR DESCRIPTION
This option allows bypassing the checks on the Media model's `getSignedUrl` method.