### PR TITLE
Add title search to CuratorPanel

### DIFF
--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -267,6 +267,7 @@ class CuratorPanel extends Component implements HasForms, HasActions
                 return $query->where('directory', $this->directory);
             })
             ->where('name', 'like', '%' . $this->search . '%')
+            ->orWhere('title', 'like', '%' . $this->search . '%')
             ->orWhere('alt', 'like', '%' . $this->search . '%')
             ->orWhere('caption', 'like', '%' . $this->search . '%')
             ->orWhere('description', 'like', '%' . $this->search . '%')


### PR DESCRIPTION
Updated the search query in CuratorPanel to include the 'title' field. This ensures search results return the correct items when a user searches using the title.