### PR TITLE
Added filament multitenancy support for media picker

### DIFF
--- a/src/Components/Forms/CuratorPicker.php
+++ b/src/Components/Forms/CuratorPicker.php
@@ -260,6 +260,7 @@ class CuratorPicker extends Field
                     'imageResizeTargetWidth' => $component->getImageResizeTargetWidth(),
                     'imageResizeTargetHeight' => $component->getImageResizeTargetHeight(),
                     'isLimitedToDirectory' => $component->isLimitedToDirectory(),
+                    'isTenantAware' => $component->isTenantAware(),
                     'isMultiple' => $component->isMultiple(),
                     'maxItems' => $component->getMaxItems(),
                     'maxSize' => $component->getMaxSize(),
@@ -331,6 +332,12 @@ class CuratorPicker extends Field
         }
 
         return $this->evaluate($this->isLimitedToDirectory) ?? config('curator.is_limited_to_directory');
+    }
+
+    public function isTenantAware(): bool
+    {
+        return filament()->hasTenancy();
+
     }
 
     public function isMultiple(): bool

--- a/src/Components/Forms/CuratorPicker.php
+++ b/src/Components/Forms/CuratorPicker.php
@@ -260,7 +260,6 @@ class CuratorPicker extends Field
                     'imageResizeTargetWidth' => $component->getImageResizeTargetWidth(),
                     'imageResizeTargetHeight' => $component->getImageResizeTargetHeight(),
                     'isLimitedToDirectory' => $component->isLimitedToDirectory(),
-                    'isTenantAware' => $component->isTenantAware(),
                     'isMultiple' => $component->isMultiple(),
                     'maxItems' => $component->getMaxItems(),
                     'maxSize' => $component->getMaxSize(),
@@ -332,12 +331,6 @@ class CuratorPicker extends Field
         }
 
         return $this->evaluate($this->isLimitedToDirectory) ?? config('curator.is_limited_to_directory');
-    }
-
-    public function isTenantAware(): bool
-    {
-        return filament()->hasTenancy();
-
     }
 
     public function isMultiple(): bool

--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -55,6 +55,8 @@ class CuratorPanel extends Component implements HasForms, HasActions
 
     public bool $isLimitedToDirectory = false;
 
+    public bool $isTenantAware = false;
+
     public bool $isMultiple = false;
 
     public ?int $maxItems = null;
@@ -113,6 +115,7 @@ class CuratorPanel extends Component implements HasForms, HasActions
             $this->imageResizeTargetWidth = $settings['imageResizeTargetWidth'];
             $this->imageResizeTargetHeight = $settings['imageResizeTargetHeight'];
             $this->isLimitedToDirectory = $settings['isLimitedToDirectory'];
+            $this->isTenantAware = $settings['isTenantAware'];
             $this->isMultiple = $settings['isMultiple'];
             $this->maxItems = $settings['maxItems'];
             $this->maxSize = $settings['maxSize'];
@@ -172,6 +175,9 @@ class CuratorPanel extends Component implements HasForms, HasActions
     public function getFiles(int $page = 0, bool $excludeSelected = false): array
     {
         $files = App::make(Media::class)->query()
+            ->when($this->isTenantAware, function ($query) {
+                return $query->where(filament()->getTenantOwnershipRelationshipName().'_id',filament()->getTenant()->id);
+            })
             ->when($this->selected, function ($query, $selected) {
                 $selected = collect($selected)->pluck('id')->toArray();
 

--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -175,7 +175,7 @@ class CuratorPanel extends Component implements HasForms, HasActions
     public function getFiles(int $page = 0, bool $excludeSelected = false): array
     {
         $files = App::make(Media::class)->query()
-            ->when($this->isTenantAware, function ($query) {
+            ->when(filament()->hasTenancy(), function ($query) {
                 return $query->where(filament()->getTenantOwnershipRelationshipName().'_id',filament()->getTenant()->id);
             })
             ->when($this->selected, function ($query, $selected) {


### PR DESCRIPTION
When using Filament Multitenancy, the Curator Picker wasn't scoping its query to use the tenant id when loading assets. This was creating problem where images of all tenants were getting loaded and user can delete image of any tenant. 

To prevent this I have added support to identify if the panel is Tenancy enabled we would scope the query to that tenant and load only the images of the tenant.