### PR TITLE
Update deprecated `utf8_encode` function to `mb_convert_encoding`

### DIFF
--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -317,7 +317,7 @@ class CuratorPanel extends Component implements HasForms, HasActions
                     if (!empty($item['exif'])) {
                         array_walk_recursive($item['exif'], function (&$entry) {
                             if (!mb_detect_encoding($entry, 'utf-8', true)) {
-                                $entry = utf8_encode($entry);
+                                $entry = mb_convert_encoding($entry, 'utf-8');
                             }
                         });
                     }


### PR DESCRIPTION
The `utf8_encode` function is deprecated in PHP8.2 and will be removed in the future.

In this PR I've replaced the function with `mb_convert_encoding`.