### PR TITLE
Fix: remove lazy attribute for panel

### DIFF
--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -21,13 +21,11 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Storage;
-use Livewire\Attributes\Lazy;
 use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\WithPagination;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
-#[Lazy]
 class CuratorPanel extends Component implements HasForms, HasActions
 {
     use InteractsWithActions;


### PR DESCRIPTION
Fixes console error about form data not being found when opening other modals.