### PR TITLE
Allow manual override of disk visibility in disk configuration

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -48,7 +48,7 @@ class Media extends Model
                 } catch (\Throwable) {
                     // ACL not supported on Storage Bucket, Laravel only throws exception here so need to be careful.
                     // so we assume it's private
-                    $isPrivate = true;
+                    $isPrivate = config(sprintf('filesystems.disks.%s.visibility', $this->disk)) !== 'public';
                 }
 
                 return $isPrivate ? Storage::disk($this->disk)->temporaryUrl(


### PR DESCRIPTION
In case the disk does not support visibility for single objects (`Storage::disk($this->disk)->getVisibility($this->path)`), Curator assumes that the disk must be private. 
In my case Cloudflare R2 supports S3, but not file-level visibility. Therefore Curator only generates those signed URLs with the endpoint URL instead of the public bucket URL from the config.

The new introduced logic checks if the disk config has the visibility set to 'public'. Otherwise it defaults to false.
Works great for me, now the correct URL is generated for Media files.