### PR TITLE
Fix relation names

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Form component
 
 ```php
 CuratorPicker::make('featured_image_id')
-    ->relationship('featured_image', 'id'),
+    ->relationship('featuredImage', 'id'),
 ```
 
 Model
@@ -173,7 +173,7 @@ Form component
 ```php
 CuratorPicker::make('product_picture_ids')
     ->multiple()
-    ->relationship('product_pictures', 'id')
+    ->relationship('productPictures', 'id')
     ->orderColumn('order'), // only necessary if you need to rename the order column
 ```
 


### PR DESCRIPTION
I tried the same relation "featuredImage" on a filament installation and by copying and pasting the code I get the `Call to undefined method App\Models\Post::featured_image()` error in a resource edit page with featured_image_id = null.