### PR TITLE
Better tenant aware

### DIFF
--- a/config/curator.php
+++ b/config/curator.php
@@ -36,6 +36,7 @@ return [
     'image_resize_target_width' => null,
     'is_limited_to_directory' => false,
     'is_tenant_aware' => true,
+    'tenant_ownership_relationship_name' => 'tenant',
     'max_size' => 5000,
     'model' => \Awcodes\Curator\Models\Media::class,
     'min_size' => 0,

--- a/database/migrations/add_tenant_aware_column_to_media_table.php.stub
+++ b/database/migrations/add_tenant_aware_column_to_media_table.php.stub
@@ -1,0 +1,27 @@
+<?php
+
+use Awcodes\Curator\Facades\Curator;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if(config('curator.is_tenant_aware')) {
+            Schema::table(app(config('curator.model'))->getTable(), function (Blueprint $table) {
+                $table->integer(config('curator.tenant_ownership_relationship_name') . '_id')->nullable();
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn(app(config('curator.model'))->getTable(), config('curator.tenant_ownership_relationship_name') . '_id'))
+            Schema::table(app(config('curator.model'))->getTable(), function(Blueprint $table) {
+                $table->dropColumn(config('curator.tenant_ownership_relationship_name') . '_id');
+            });
+        }
+    }
+};

--- a/src/Actions/MediaAction.php
+++ b/src/Actions/MediaAction.php
@@ -44,6 +44,7 @@ class MediaAction extends Action
                     'imageResizeMode' => Config::get('curator.image_resize_mode'),
                     'isLimitedToDirectory' => false,
                     'isTenantAware' => Config::get('curator.is_tenant_aware'),
+                    'tenantOwnershipRelationshipName' => Config::get('curator.tenant_ownership_relationship_name'),
                     'isMultiple' => false,
                     'maxItems' => 1,
                     'maxSize' => Config::get('curator.max_size'),

--- a/src/Components/Forms/CuratorPicker.php
+++ b/src/Components/Forms/CuratorPicker.php
@@ -364,7 +364,7 @@ class CuratorPicker extends Field
         return $this->evaluate($this->isTenantAware) ?? config('curator.is_tenant_aware');
     }
 
-    public function tenantOwnershipRelationshipName(): bool
+    public function tenantOwnershipRelationshipName(): string
     {
         return $this->tenantOwnershipRelationshipName ?? config('curator.tenant_ownership_relationship_name');
     }

--- a/src/Components/Forms/CuratorPicker.php
+++ b/src/Components/Forms/CuratorPicker.php
@@ -44,6 +44,8 @@ class CuratorPicker extends Field
 
     protected bool|Closure|null $isTenantAware = null;
 
+    protected string|null $tenantOwnershipRelationshipName = null;
+
     protected bool|Closure|null $shouldLazyLoad = null;
 
     protected int|Closure|null $maxItems = null;
@@ -278,6 +280,7 @@ class CuratorPicker extends Field
                     'imageResizeTargetHeight' => $component->getImageResizeTargetHeight(),
                     'isLimitedToDirectory' => $component->isLimitedToDirectory(),
                     'isTenantAware' => $component->isTenantAware(),
+                    'tenantOwnershipRelationshipName' => $component->tenantOwnershipRelationshipName(),
                     'isMultiple' => $component->isMultiple(),
                     'maxItems' => $component->getMaxItems(),
                     'maxSize' => $component->getMaxSize(),
@@ -359,6 +362,11 @@ class CuratorPicker extends Field
     public function isTenantAware(): bool
     {
         return $this->evaluate($this->isTenantAware) ?? config('curator.is_tenant_aware');
+    }
+
+    public function tenantOwnershipRelationshipName(): bool
+    {
+        return $this->evaluate($this->tenantOwnershipRelationshipName) ?? config('curator.tenant_ownership_relationship_name');
     }
 
     public function lazyLoad(bool|Closure $condition = true): static

--- a/src/Components/Forms/CuratorPicker.php
+++ b/src/Components/Forms/CuratorPicker.php
@@ -366,7 +366,7 @@ class CuratorPicker extends Field
 
     public function tenantOwnershipRelationshipName(): bool
     {
-        return $this->evaluate($this->tenantOwnershipRelationshipName) ?? config('curator.tenant_ownership_relationship_name');
+        return $this->tenantOwnershipRelationshipName ?? config('curator.tenant_ownership_relationship_name');
     }
 
     public function lazyLoad(bool|Closure $condition = true): static

--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -5,6 +5,7 @@ namespace Awcodes\Curator\Components\Forms;
 use Awcodes\Curator\Concerns\CanGeneratePaths;
 use Awcodes\Curator\Concerns\CanNormalizePaths;
 use Awcodes\Curator\PathGenerators\Contracts\PathGenerator;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\BaseFileUpload;
 use Filament\Forms\Components\FileUpload;
 use Illuminate\Support\Facades\App;

--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -142,8 +142,8 @@ class Uploader extends FileUpload
                 'ext' => $extension,
             ];
 
-            if($component->isTenantAware() && Filament::hasTenancy()) {
-                $data[$component->tenantOwnershipRelationshipName() . '_id'] = Filament::getTenant()->id;
+            if(config('curator.is_tenant_aware') && Filament::hasTenancy()) {
+                $data[config('curator.tenant_ownership_relationship_name') . '_id'] = Filament::getTenant()->id;
             }
 
             return $data;

--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -127,7 +127,7 @@ class Uploader extends FileUpload
                 $component->getDiskName()
             );
 
-            return [
+            $data = [
                 'disk' => $component->getDiskName(),
                 'directory' => $component->getDirectory(),
                 'visibility' => $component->getVisibility(),
@@ -140,6 +140,12 @@ class Uploader extends FileUpload
                 'type' => $file->getMimeType(),
                 'ext' => $extension,
             ];
+
+            if($component->isTenantAware() && Filament::hasTenancy()) {
+                $data[$component->tenantOwnershipRelationshipName() . '_id'] = Filament::getTenant()->id;
+            }
+
+            return $data;
         });
     }
 }

--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -57,6 +57,8 @@ class CuratorPanel extends Component implements HasForms, HasActions
 
     public bool|Closure $isTenantAware = true;
 
+    public string|null $tenantOwnershipRelationshipName = null;
+
     public bool $isMultiple = false;
 
     public ?int $maxItems = null;
@@ -119,6 +121,7 @@ class CuratorPanel extends Component implements HasForms, HasActions
             $this->isLimitedToDirectory = $settings['isLimitedToDirectory'];
             $this->isMultiple = $settings['isMultiple'];
             $this->isTenantAware = $settings['isTenantAware'];
+            $this->tenantOwnershipRelationshipName = $settings['tenantOwnershipRelationshipName'];
             $this->maxItems = $settings['maxItems'];
             $this->maxSize = $settings['maxSize'];
             $this->maxWidth = $settings['maxWidth'];
@@ -188,7 +191,7 @@ class CuratorPanel extends Component implements HasForms, HasActions
     {
         $files = App::make(Media::class)->query()
             ->when(filament()->hasTenancy() && $this->isTenantAware, function ($query) {
-                return $query->where(filament()->getTenantOwnershipRelationshipName() . '_id', filament()->getTenant()->id);
+                return $query->where($this->tenantOwnershipRelationshipName . '_id', filament()->getTenant()->id);
             })
             ->when($this->selected, function ($query, $selected) {
                 $selected = collect($selected)->pluck('id')->toArray();

--- a/src/CuratorServiceProvider.php
+++ b/src/CuratorServiceProvider.php
@@ -28,7 +28,7 @@ class CuratorServiceProvider extends PackageServiceProvider
             ->hasRoute('web')
             ->hasViews()
             ->hasTranslations()
-            ->hasMigration('create_media_table')
+            ->hasMigrations(['create_media_table','add_tenant_aware_column_to_media_table'])
             ->hasCommands([
                 Commands\UpgradeCommand::class,
             ])

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -7,6 +7,7 @@ use Awcodes\Curator\Components\Forms\Uploader;
 use Awcodes\Curator\Components\Tables\CuratorColumn;
 use Awcodes\Curator\CuratorPlugin;
 use Exception;
+use Filament\Facades\Filament;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -21,6 +22,16 @@ class MediaResource extends Resource
     public static function getModel(): string
     {
         return config('curator.model');
+    }
+
+    public static function isScopedToTenant(): bool
+    {
+        return config('curator.is_tenant_aware') ?? static::$isScopedToTenant;
+    }
+
+    public static function getTenantOwnershipRelationshipName(): string
+    {
+        return config('curator.tenant_ownership_relationship_name') ?? Filament::getTenantOwnershipRelationshipName();
     }
 
     public static function getModelLabel(): string

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -12,6 +12,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 use function Awcodes\Curator\is_media_resizable;
@@ -56,7 +57,12 @@ class MediaResource extends Resource
     public static function getNavigationBadge(): ?string
     {
         return CuratorPlugin::get()->getNavigationCountBadge() ?
-            number_format(static::getModel()::count()) : null;
+            (Filament::hasTenancy() && Config::get('curator.is_tenant_aware')) ?
+                static::getEloquentQuery()
+                ->where(Filament::getTenantOwnershipRelationshipName() . '_id', Filament::getTenant()->id)
+                ->count()
+            : number_format(static::getModel()::count())
+            : null;
     }
 
     public static function form(Form $form): Form

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -70,7 +70,7 @@ class MediaResource extends Resource
         return CuratorPlugin::get()->getNavigationCountBadge() ?
             (Filament::hasTenancy() && Config::get('curator.is_tenant_aware')) ?
                 static::getEloquentQuery()
-                ->where(Filament::getTenantOwnershipRelationshipName() . '_id', Filament::getTenant()->id)
+                ->where(Config::get('curator.tenant_ownership_relationship_name') . '_id', Filament::getTenant()->id)
                 ->count()
             : number_format(static::getModel()::count())
             : null;


### PR DESCRIPTION
The tenant aware column name now is defined in the config because per Filament panel there can be a different tenantOwnershipRelationshipName. 

It changes isScopedToTenant() in the Resource Model based on the config.

So this makes only the files visible in the corresponding tenant.