### PR TITLE
fix: add the missing bracket to the migration file

### DIFF
--- a/database/migrations/add_tenant_aware_column_to_media_table.php.stub
+++ b/database/migrations/add_tenant_aware_column_to_media_table.php.stub
@@ -18,7 +18,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasColumn(app(config('curator.model'))->getTable(), config('curator.tenant_ownership_relationship_name') . '_id'))
+        if (Schema::hasColumn(app(config('curator.model'))->getTable(), config('curator.tenant_ownership_relationship_name') . '_id')) {
             Schema::table(app(config('curator.model'))->getTable(), function(Blueprint $table) {
                 $table->dropColumn(config('curator.tenant_ownership_relationship_name') . '_id');
             });


### PR DESCRIPTION
This PR adds the missing bracket to the [add_tenant_aware_column_to_media_table.php.stub](https://github.com/awcodes/filament-curator/commit/1d9a760bff25ee4358ba81de6d4306eb4158d2e4#diff-ec803d6ecb8461274b0dcea43484770871d2b59d9d7d568ae21def55ca1c3add) migration stub file that throws an error during the migration process.