### PR TITLE
`ctrl+click` or `cmd+click` keybinding for multiple selection

### DIFF
--- a/resources/views/components/modals/curator-panel.blade.php
+++ b/resources/views/components/modals/curator-panel.blade.php
@@ -3,7 +3,7 @@
         handleItemClick: function (mediaId = null, event) {
             if (! mediaId) return;
 
-            if ($wire.isMultiple && event && event.metaKey) {
+            if ($wire.isMultiple && event && (event.metaKey || event.ctrlKey)) {
                 if (this.isSelected(mediaId)) {
                     let toRemove = Object.values($wire.selected).find(obj => obj.id == mediaId)
                     $wire.removeFromSelection(toRemove.id);


### PR DESCRIPTION
On Windows OS the `metaKey` is the `Windows Key ⊞` but `ctrl` is often used for multiple selections.

✅ This PR adds this feature.