### PR TITLE
Add Ability to Disable Curation Tab and Upload New Tab via Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,24 @@ You can also change which formats are available for curations by changing the `c
 ],
 ```
 
+If you wish to disable the "Curation" tab in the Media Editor you can do so by setting `tabs.display_curation`
+to `false` in the config file. The default is `true`.
+
+```php
+'tabs' => [
+    'display_curation' => false,
+],
+```
+
+If you wish to disable the "Upload New" tab in the Media Editor you can do so by setting `tabs.display_upload_new`
+to `false` in the config file. The default is `true`.
+
+```php
+'tabs' => [
+    'display_upload_new' => false,
+],
+```
+
 ### Glider Blade Component
 
 To make it as easy as possible to output your media, Curator comes with an

--- a/config/curator.php
+++ b/config/curator.php
@@ -53,5 +53,9 @@ return [
     'should_preserve_filenames' => false,
     'should_register_navigation' => true,
     'visibility' => 'public',
+    'tabs' => [
+        'display_curation' => true,
+        'display_upload_new' => true,
+    ],
     'multi_select_key' => 'metaKey',
 ];

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -108,7 +108,7 @@ class MediaResource extends Resource
                                             }),
                                     ]),
                                 Forms\Components\Tabs\Tab::make(trans('curator::forms.sections.curation'))
-                                    ->visible(fn ($record) => is_media_resizable($record->ext))
+                                    ->visible(fn ($record) => is_media_resizable($record->ext) && config('curator.tabs.display_curation'))
                                     ->schema([
                                         Forms\Components\Repeater::make('curations')
                                             ->label(trans('curator::forms.sections.curation'))
@@ -125,6 +125,7 @@ class MediaResource extends Resource
                                             ]),
                                     ]),
                                 Forms\Components\Tabs\Tab::make(trans('curator::forms.sections.upload_new'))
+                                    ->visible(config('curator.tabs.display_upload_new'))
                                     ->schema([
                                         static::getUploaderField()
                                             ->helperText(trans('curator::forms.sections.upload_new_helper')),


### PR DESCRIPTION
This PR adds `tabs.display_curation` and `tabs.display_upload_new` to the `curator` config file with a default value of `true`.

Setting `tabs.display_curation` to `false` will hide the "Curation" tab on the Edit Media screen. This is useful for using Curator as a simple media library, but don't want to surface image manipulation features to your users. You could also use a class method to return `true` or `false` depending on the user's permissions.

Setting `tabs.display_upload_new` to `false` will hide the "Upload New" tab on the Edit Media screen. This is useful when you wish for users to not be able to override media files but upload new ones instead.