### PR TITLE
Fix: Curator Cloud Disks and the Livewire Temporary Disk

### DIFF
--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -100,13 +100,7 @@ class Uploader extends FileUpload
             $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
 
             if (is_media_resizable($extension)) {
-                if (
-                    (
-                        in_array($component->getDiskName(), config('curator.cloud_disks'))
-                        && config('livewire.temporary_file_upload.directory') !== null
-                    )
-                    || in_array(config('livewire.temporary_file_upload.disk'), config('curator.cloud_disks'))
-                ) {
+                if (in_array(config('livewire.temporary_file_upload.disk'), config('curator.cloud_disks')) && config('livewire.temporary_file_upload.directory') !== null) {
                     $content = Storage::disk($component->getDiskName())->get($file->path());
                 } else {
                     $content = $file->getRealPath();


### PR DESCRIPTION
In cases where the `curator.disk` is also declared in `curator.cloud_disks`, and `livewire.temporary_file_upload.disk` is not actually a cloud disk, an error is thrown when saving a new image due to the file being in another disk. I am not entirely sure what the logic was intended to be starting at line 102, but I have reworked it a bit based on what I think it should do, and it seems to be working for me now. If I am missing any points to how this should work let me know.