### PR TITLE
add navigation label config  and update Translation

### DIFF
--- a/config/curator.php
+++ b/config/curator.php
@@ -45,6 +45,7 @@ return [
         'label' => 'Media',
         'plural_label' => 'Media',
         'navigation_group' => null,
+        'navigation_label' => 'Media',
         'navigation_icon' => 'heroicon-o-photo',
         'navigation_sort' => null,
         'navigation_count_badge' => false,

--- a/resources/lang/ar/forms.php
+++ b/resources/lang/ar/forms.php
@@ -8,10 +8,12 @@ return [
         'preview' => 'عرض',
         'upload_new' => 'تحميل جديد',
         'curation' => 'تنظيم',
+        'exif' => 'بيانات الملف',
+        'upload_new_helper' => 'اذا كان لديك اي مصغرات لهذه الصورة يجب اعادة انشاءها مرة اخرى',
     ],
     'fields' => [
-        'alt' => 'وصف نصي',
-        'alt_hint' => 'وصف؟',
+        'alt' => 'نص بديل',
+        'alt_hint' => 'ماهو النص البديل؟',
         'caption' => 'تعليق',
         'description' => 'وصف',
         'file' => 'ملف',
@@ -23,5 +25,10 @@ return [
     ],
     'curations' => [
         'button_label' => 'إنشاء تنظيم',
+    ],
+    'multi_upload' => [
+        'action_label' => 'رفع ملفات متعدد',
+        'modal_heading' => 'رفع عدة ملفات',
+        'modal_file_label' => 'ملفات',
     ],
 ];

--- a/resources/lang/ar/views.php
+++ b/resources/lang/ar/views.php
@@ -11,6 +11,8 @@ return [
         'file_url' => 'رابط الملف',
         'file' => 'الملف',
         'ext' => 'الإمتداد',
+        'copy_url' => 'نسخ الرابط',
+        'url_copied' => 'تم النسخ!',
     ],
     'picker' => [
         'button' => 'إضافة وسائط',
@@ -19,6 +21,7 @@ return [
         'edit' => 'تعديل',
         'download' => 'تنزيل',
         'remove' => 'حذف',
+        'clear' => 'حذف الكل',
     ],
     'panel' => [
         'button' => 'إضافة وسائط',
@@ -40,10 +43,13 @@ return [
         'edit' => 'تعديل',
         'download' => 'تنزيل',
         'remove' => 'حذف',
+        'deselect_all' => 'إلغاء تحديد الكل',
+        'add_multiple_file' => ':key + مع الضغط لإختيار عدة ملفات.',
     ],
     'curation' => [
         'heading' => 'تنظيم',
         'adjustments' => 'تعديل',
+        'cancel' => 'إلغاء',
         'custom' => 'مخصص',
         'key' => 'المفتاح',
         'key_helper' => 'هذا هو المرجع المستخدم لاسترداد تنظيم طريقة العرض.',
@@ -55,5 +61,11 @@ return [
         'crop_mode' => 'وضع القطع',
         'reset' => 'إعادة تعيين',
         'save_curation' => 'حفظ التنظيم',
+        'height' => 'الإرتفاع',
+        'width' => 'العرض',
+        'format' => 'التنسيق',
+        'quality' => 'الدقة',
+        'rotate' => 'التدوير',
+        'rotate_deg' => 'درجة',
     ],
 ];

--- a/src/CuratorPlugin.php
+++ b/src/CuratorPlugin.php
@@ -16,6 +16,8 @@ class CuratorPlugin implements Plugin
 
     protected string | Closure | null $navigationGroup = null;
 
+    protected string | Closure | null $navigationLabel = null;
+
     protected ?string $navigationIcon = null;
 
     protected ?int $navigationSort = null;
@@ -85,6 +87,11 @@ class CuratorPlugin implements Plugin
         return $this->evaluate($this->navigationGroup) ?? config('curator.resources.navigation_group');
     }
 
+    public function getNavigationLabel(): ?string
+    {
+        return $this->evaluate($this->navigationLabel) ?? config('curator.resources.navigation_label');
+    }
+
     public function getNavigationIcon(): ?string
     {
         return $this->navigationIcon ?? config('curator.resources.navigation_icon');
@@ -113,6 +120,13 @@ class CuratorPlugin implements Plugin
     public function navigationGroup(string | Closure | null $group = null): static
     {
         $this->navigationGroup = $group;
+
+        return $this;
+    }
+
+    public function navigationLabel(string | Closure | null $label = null): static
+    {
+        $this->navigationLabel = $label;
 
         return $this;
     }

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -48,7 +48,7 @@ class MediaResource extends Resource
 
     public static function getNavigationLabel(): string
     {
-        return Str::title(static::getPluralModelLabel()) ?? Str::title(static::getModelLabel());
+        return CuratorPlugin::get()->getNavigationLabel() ?? Str::title(static::getPluralModelLabel()) ?? Str::title(static::getModelLabel());
     }
 
     public static function getNavigationIcon(): string


### PR DESCRIPTION
so currently the `navigation label` and the `label` read the same phrase, and both in plural format.
but in some language the `label` should be in singular format and the `navigation label` in plural.

so I added a new config to set the navigation label, and use it in `getNavigationLabel` of the resource, but still default to the Plural label or the model label if not set.