### PR TITLE
Add `should_check_visibility` config to allow circumventing Storage disk operations

### DIFF
--- a/config/curator.php
+++ b/config/curator.php
@@ -53,7 +53,7 @@ return [
     ],
     'should_preserve_filenames' => false,
     'should_register_navigation' => true,
-    'should_check_visibility' => true,
+    'should_check_exists' => true,
     'visibility' => 'public',
     'tabs' => [
         'display_curation' => true,

--- a/config/curator.php
+++ b/config/curator.php
@@ -53,6 +53,7 @@ return [
     ],
     'should_preserve_filenames' => false,
     'should_register_navigation' => true,
+    'should_check_visibility' => true,
     'visibility' => 'public',
     'tabs' => [
         'display_curation' => true,

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -40,7 +40,7 @@ class Media extends Model
     {
         return Attribute::make(
             get: function () {
-                if (! config('curator.should_check_visibility', true)) {
+                if (! config('curator.should_check_exists', true)) {
                     return Storage::disk($this->disk)->url($this->path);
                 }
 

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -40,6 +40,10 @@ class Media extends Model
     {
         return Attribute::make(
             get: function () {
+                if (! config('curator.should_check_visibility', true)) {
+                    return Storage::disk($this->disk)->url($this->path);
+                }
+
                 if (Storage::disk($this->disk)->exists($this->path) === false) {
                     return '';
                 }


### PR DESCRIPTION
I brought this up in Discord awhile back but was a little late on getting a PR in. 

This adds a `should_check_visibility` config to allow bypassing the `Storage::exists()` and `Storage::getVisibility()` checks when fetching a media URL.

These operations are seemingly quite intensive when media is stored in an S3 bucket.

Not 100% sold on the config key name – if you have a better idea, feel free.