### PR TITLE
Fix getFiles query logic to prevent duplicate records

### DIFF
--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -204,12 +204,12 @@ class CuratorPanel extends Component implements HasActions, HasForms
                 return $query->where('directory', $this->directory);
             })
             ->when($this->types, function ($query) {
-                $types = $this->types;
-                $query = $query->whereIn('type', $types);
-                $wildcardTypes = collect($types)->filter(fn ($type) => str_contains($type, '*'));
-                $wildcardTypes?->map(fn ($type) => $query->orWhere('type', 'LIKE', str_replace('*', '%', $type)));
-
-                return $query;
+                return $query->where(function($query){
+                    $types = $this->types;
+                    $query = $query->whereIn('type', $types);
+                    $wildcardTypes = collect($types)->filter(fn ($type) => str_contains($type, '*'));
+                    $wildcardTypes?->map(fn ($type) => $query->orWhere('type', 'LIKE', str_replace('*', '%', $type)));
+                });
             })
             ->orderBy('created_at', $this->defaultSort);
 


### PR DESCRIPTION
This pull request fixes an issue in the getFiles method where the query logic caused duplicate file records due to improper condition grouping.

Before the Change
The query structure was:
```select * from `media` where `id` not in (?, ?) and `type` in (?) or `type` LIKE ? order by `created_at` desc```

After the Change
The query structure is now:
```select * from `media` where `id` not in (?, ?) and (`type` in (?) or `type` LIKE ?) order by `created_at` desc```

This ensures all conditions are properly applied, preventing duplicates.