### PR TITLE
Ensure curation visibility matches original image

### DIFF
--- a/src/Components/Modals/CuratorCuration.php
+++ b/src/Components/Modals/CuratorCuration.php
@@ -64,7 +64,9 @@ class CuratorCuration extends Component
         // save image to directory base on media
         $curationPath = $this->media->directory . '/' . $this->media->name . '/' . $data['key'] . '.' . $extension;
 
-        Storage::disk($this->media->disk)->put($curationPath, $image->stream());
+        Storage::disk($this->media->disk)->put($curationPath, $image->stream(), [
+            'visibility' => $this->media->visibility,
+        ]);
 
         $curation = [
             'key' => $data['key'] ?? $aspectWidth . 'x' . $aspectHeight,


### PR DESCRIPTION
Hello @awcodes!

I was wondering if you thought this implementation would make sense to ensure that curations _always_ have the same visibility as the original image they are a curation of. 

Although Curations are saved into the media table with the same visibility of their original image, when using some S3 compatible storage options (Digital Ocean Spaces specifically 😮‍💨), all resources are created as private unless otherwise specified. This results in them showing as public per the Media/Curation record, but actually existing as private since visibility was not specified.

This would fix that issue, and ensure that the functionality remains the same for everyone else who may be able to configure default visibility on a bucket differently.