### PR TITLE
Fix - upload image with uppercase extensions

### DIFF
--- a/resources/views/components/tables/curator-column.blade.php
+++ b/resources/views/components/tables/curator-column.blade.php
@@ -41,7 +41,7 @@
                 $ring . ' ring-white dark:ring-gray-900' => $imageCount > 1,
             ])
         >
-            @if (\Awcodes\Curator\is_media_resizable($item->ext))
+            @if (\Awcodes\Curator\is_media_resizable($item->type))
                 @php
                     $img_width = $width ? (int)$width : null;
                     $img_height = $height ? (int)$height : null;

--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -99,7 +99,7 @@ class Uploader extends FileUpload
 
             $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
 
-            if (is_media_resizable($extension)) {
+            if (is_media_resizable($file->getMimeType())) {
                 if (in_array(config('livewire.temporary_file_upload.disk'), config('curator.cloud_disks')) && config('livewire.temporary_file_upload.directory') !== null) {
                     $content = Storage::disk($component->getDiskName())->get($file->path());
                 } else {

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -95,7 +95,7 @@ class Media extends Model
     protected function resizable(): Attribute
     {
         return Attribute::make(
-            get: fn () => is_media_resizable($this->ext),
+            get: fn () => is_media_resizable($this->type),
         );
     }
 

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -113,7 +113,7 @@ class MediaResource extends Resource
                                             }),
                                     ]),
                                 Forms\Components\Tabs\Tab::make(trans('curator::forms.sections.curation'))
-                                    ->visible(fn ($record) => is_media_resizable($record->ext) && config('curator.tabs.display_curation'))
+                                    ->visible(fn ($record) => is_media_resizable($record->type) && config('curator.tabs.display_curation'))
                                     ->schema([
                                         Forms\Components\Repeater::make('curations')
                                             ->label(trans('curator::forms.sections.curation'))

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -8,9 +8,9 @@ use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Str;
 
 if (! function_exists('is_media_resizable')) {
-    function is_media_resizable(string $ext): bool
+    function is_media_resizable(string $type): bool
     {
-        return in_array($ext, ['jpeg', 'jpg', 'png', 'webp', 'bmp']);
+        return in_array($type, ['image/jpeg', 'image/png','image/gif', 'image/webp', 'image/bmp']);
     }
 }
 


### PR DESCRIPTION
There was an issue where images with uppercase extensions (such as .JPG and .PNG) were not being recognized correctly. This has been resolved by converting the extensions to their mime types, ensuring they are processed correctly regardless of whether the extension is in uppercase or lowercase.