### PR TITLE
Change deprecated `utf8_encode`  to `mb_convert_encoding`

### DIFF
--- a/src/Actions/MultiUploadAction.php
+++ b/src/Actions/MultiUploadAction.php
@@ -44,7 +44,7 @@ class MultiUploadAction extends Action
                     if (! empty($item['exif'])) {
                         array_walk_recursive($item['exif'], function (&$entry) {
                             if (! mb_detect_encoding($entry, 'utf-8', true)) {
-                                $entry = utf8_encode($entry);
+                                $entry = mb_convert_encoding($entry, 'utf-8');
                             }
                         });
                     }

--- a/src/Observers/MediaObserver.php
+++ b/src/Observers/MediaObserver.php
@@ -25,7 +25,7 @@ class MediaObserver
                     // Fix malformed utf-8 characters
                     array_walk_recursive($v, function (&$entry) {
                         if (! mb_detect_encoding($entry, 'utf-8', true)) {
-                            $entry = utf8_encode($entry);
+                            $entry = mb_convert_encoding($entry, 'utf-8');
                         }
                     });
 


### PR DESCRIPTION
The `utf8_encode` function is deprecated in `PHP 8.2` and will be removed.