### PR TITLE
:sparkles: Introduce alt parameter to glider component

### DIFF
--- a/resources/views/components/glider.blade.php
+++ b/resources/views/components/glider.blade.php
@@ -2,7 +2,7 @@
     @if (str($media->type)->contains('image'))
         <img
             src="{{ $source }}"
-            alt="{{ $media->alt }}"
+            alt="{{ $attributes->get('alt', $media->alt) }}"
             @if ($width && $height)
                 width="{{ $width }}"
                 height="{{ $height }}"


### PR DESCRIPTION
This pull request includes a small but important change to the `resources/views/components/glider.blade.php` file. The change improves the handling of the `alt` attribute for images, making it more flexible.

* [`resources/views/components/glider.blade.php`](diffhunk://#diff-30bf293d3b819a815143780356fdfb61382d4635db489ee39cd6172115e5fdf2L5-R5): Modified the `alt` attribute to use the value from `$attributes` if available, otherwise default to `$media->alt`.