### PR TITLE
Fix deprecated nested ternary expressions and file extension preview

### DIFF
--- a/resources/views/components/forms/edit-preview.blade.php
+++ b/resources/views/components/forms/edit-preview.blade.php
@@ -25,6 +25,7 @@
                 icon-size="xl"
                 class="p-4 rounded"
                 :type="$file['type']"
+                :extension="$file['ext']"
             />
         @endif
 

--- a/resources/views/components/forms/preview.blade.php
+++ b/resources/views/components/forms/preview.blade.php
@@ -20,6 +20,7 @@
             icon-size="xl"
             class="p-4 rounded"
             :type="$record->type"
+            :extension="$record->ext"
         />
     @endif
 </div>

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -74,11 +74,11 @@ class MediaResource extends Resource
     public static function getNavigationBadge(): ?string
     {
         return CuratorPlugin::get()->getNavigationCountBadge() ?
-            (Filament::hasTenancy() && Config::get('curator.is_tenant_aware')) ?
+            (Filament::hasTenancy() && Config::get('curator.is_tenant_aware') ?
                 static::getEloquentQuery()
                     ->where(Config::get('curator.tenant_ownership_relationship_name') . '_id', Filament::getTenant()->id)
                     ->count()
-            : number_format(static::getModel()::count())
+            : number_format(static::getModel()::count()))
             : null;
     }
 


### PR DESCRIPTION
This PR updates the `getNavigationBadge` method to use parentheses in nested ternary expressions, which is deprecated in PHP 7.4.