### PR TITLE
Fix double root issue

### DIFF
--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -101,7 +101,7 @@ class Uploader extends FileUpload
 
             if (is_media_resizable($file->getMimeType())) {
                 if (in_array(config('livewire.temporary_file_upload.disk'), config('curator.cloud_disks')) && config('livewire.temporary_file_upload.directory') !== null) {
-                    $content = Storage::disk($component->getDiskName())->get($file->path());
+                    $content = $file->get();
                 } else {
                     $content = $file->getRealPath();
                 }


### PR DESCRIPTION
I have a filesystem (S3) configured with a custom `root` set to `public` which means any file I put or get from that filesystem will get prefixed with `public/`. In the `Uploader` class it attempts to read the contents of my upload by using the `Storage` facade and by getting the path by using `$file->path()` but this actually returns the prefixed path.

So `$file->path()` returns `public/livewire-tmp/foo.png` which means when I attempt to read that file from my filesystem it actually looks for the file `public/public/livewire-tmp/foo.png` in my S3 bucket resulting in an error.

Livewire actually provides a `get()` method on the [`TemporaryUploadedFile`](https://github.com/livewire/livewire/blob/7bbf80d93db9b866776bf957ca6229364bca8d87/src/Features/SupportFileUploads/TemporaryUploadedFile.php#L150-L153) class which solves this exact issue.