### PR TITLE
Allow editing name before upload

### DIFF
--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -78,9 +78,19 @@ class Uploader extends FileUpload
         $this->state($state);
     }
 
+    public function getSuggestedFileName(TemporaryUploadedFile $file){
+        return $this->shouldPreserveFilenames()
+            ? Str::of(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))->slug()
+            : (string) Str::uuid();
+    }
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        $this->getUploadedFileNameForStorageUsing(function (Uploader $component, TemporaryUploadedFile $file) {
+            return $component->getSuggestedFileName($file);
+        });
 
         $this->saveUploadedFileUsing(function (BaseFileUpload $component, TemporaryUploadedFile $file): ?array {
             try {
@@ -91,9 +101,7 @@ class Uploader extends FileUpload
                 return null;
             }
 
-            $filename = $component->shouldPreserveFilenames()
-                ? Str::of(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))->slug()
-                : (string) Str::uuid();
+            $filename = $component->getUploadedFileNameForStorage($file);
 
             $extension = $file->getClientOriginalExtension();
 

--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -97,7 +97,16 @@ class MediaResource extends Resource
                             ->hiddenOn('edit')
                             ->schema([
                                 static::getUploaderField()
-                                    ->required(),
+                                    ->required()
+                                    ->live()
+                                    ->afterStateUpdated(function($state, $set, $component){
+                                        $name = $component->getSuggestedFileName($state);
+                                        $set('name', $name);
+                                    })
+                                    ->getUploadedFileNameForStorageUsing(function ($get, $file, $component) {
+                                        $name = $get('name');
+                                        return !$name->isEmpty() ? Str::slug($name) : $component->getSuggestedFileName($file);
+                                    })
                             ]),
                         Forms\Components\Tabs::make('image')
                             ->hiddenOn('create')
@@ -287,8 +296,7 @@ class MediaResource extends Resource
         return [
             Forms\Components\TextInput::make('name')
                 ->label(trans('curator::forms.fields.name'))
-                ->hiddenOn('create')
-                ->required()
+                ->required(fn ($operation): bool => $operation == 'edit')
                 ->dehydrateStateUsing(function ($component, $state) {
                     $slugged = Str::slug($state);
                     $component->state($slugged);


### PR DESCRIPTION
My proposal for solving https://github.com/awcodes/filament-curator/discussions/567

This re-introduces the `getUploadedFileNameForStorageUsing` method from the base class into the `saveUploadedFileUsing` code. The original name generation code is extracted into the `getSuggestedFileName` function, which can then be used by the media form.

The MediaResource now populates the `name` field once the temporary file is uploaded, and reads back from the `name` field before saving the file to its final destination. `name` is also no longer required on create and will use the default suggestion if empty, so it should work if the user's JS is disabled for any reason.

I haven't made this opt in since it doesn't actually add any new required steps to the user's workflow.

This also respects the `should_preserve_filename` option.