### PR TITLE
Fix Check Policy Create Update Delete Action in Panel and Picker

### DIFF
--- a/resources/views/components/forms/picker.blade.php
+++ b/resources/views/components/forms/picker.blade.php
@@ -31,6 +31,17 @@
             style="{{ $itemsCount === 1 ? '--grid-column-count: 1' : '' }}"
         >
             @foreach ($items as $uuid => $item)
+              @php
+                    $media = App::make(\Awcodes\Curator\Models\Media::class)->find($item["id"]);
+                    $canEdit = $media && Gate::allows('update', $media);
+
+                    $groupActions = array_filter([
+                        $getAction('view')(['url' => $item['url']]),
+                        $canEdit ? $getAction('edit')(['id' => $item['id']]) : null, 
+                        $getAction('download')(['uuid' => $uuid]),
+                        $getAction('remove')(['uuid' => $uuid]),
+                    ]);
+              @endphp
                 <li
                     wire:key="{{ $this->getId() }}.{{ $uuid }}.{{ $field::class }}.item"
                     x-sortable-item="{{ $uuid }}"
@@ -80,12 +91,7 @@
 
                                     <div class="flex items-center justify-center flex-none w-8 h-8">
                                         <x-filament-actions::group
-                                            :actions="[
-                                                $getAction('view')(['url' => $item['url']]),
-                                                $getAction('edit')(['id' => $item['id']]),
-                                                $getAction('download')(['uuid' => $uuid]),
-                                                $getAction('remove')(['uuid' => $uuid]),
-                                            ]"
+                                            :actions="$groupActions"
                                             color="gray"
                                             size="xs"
                                             dropdown-placement="bottom-end"
@@ -143,12 +149,7 @@
 
                                 <div class="flex items-center justify-center flex-none w-10 h-10">
                                     <x-filament-actions::group
-                                        :actions="[
-                                            $getAction('view')(['url' => $item['url']]),
-                                            $getAction('edit')(['id' => $item['id']]),
-                                            $getAction('download')(['uuid' => $uuid]),
-                                            $getAction('remove')(['uuid' => $uuid]),
-                                        ]"
+                                        :actions="$groupActions"
                                         color="gray"
                                         size="xs"
                                         dropdown-placement="bottom-end"

--- a/resources/views/components/forms/picker.blade.php
+++ b/resources/views/components/forms/picker.blade.php
@@ -33,7 +33,12 @@
             @foreach ($items as $uuid => $item)
               @php
                     $media = App::make(\Awcodes\Curator\Models\Media::class)->find($item["id"]);
-                    $canEdit = $media && Gate::allows('update', $media);
+
+                     // Retrieve the policy, if any, for this media.
+                    $policy = $media ? Gate::getPolicyFor($media) : null; 
+
+                    // For edit: if no policy exists, allow the action; otherwise, check the 'update' ability.
+                    $canEdit = $media && (is_null($policy) || Gate::allows('update', $media));
 
                     $groupActions = array_filter([
                         $getAction('view')(['url' => $item['url']]),

--- a/resources/views/components/modals/curator-panel.blade.php
+++ b/resources/views/components/modals/curator-panel.blade.php
@@ -197,13 +197,13 @@
                             // Checks for the 'create' ability.
                             function canCreateMedia() {
                                 // Create a dummy instance for checking the policy.
-                                $dummy = new Media();
+                                $dummy = App::make(Media::class);
                                 $policy = Gate::getPolicyFor($dummy);
                                 // If no policy is registered, allow the action.
                                 if (is_null($policy)) {
                                     return true;
                                 }
-                                return Gate::allows('create', Media::class);
+                                return Gate::allows('create',  $dummy);
                             }
 
                             // Checks for the 'update' ability on a specific media instance.

--- a/resources/views/components/modals/curator-panel.blade.php
+++ b/resources/views/components/modals/curator-panel.blade.php
@@ -189,12 +189,14 @@
                     </div>
 
                     <div class="flex items-center justify-start mt-auto gap-3 py-3 px-4 border-t border-gray-300 bg-gray-200 dark:border-gray-800 dark:bg-black/10">
-                        @if (count($selected) !== 1)
-                            <div>
-                                {{ $this->addFilesAction }}
-                                {{ $this->addInsertFilesAction }}
-                            </div>
-                        @endif
+                        @can('create', \Awcodes\Curator\Models\Media::class)
+                            @if (count($selected) !== 1)
+                                <div>
+                                    {{ $this->addFilesAction }}
+                                    {{ $this->addInsertFilesAction }}
+                                </div>
+                            @endif
+                        @endcan
                         @if (count($selected) === 1)
                             <div class="flex gap-3">
                                 {{ $this->updateFileAction }}

--- a/resources/views/components/modals/curator-panel.blade.php
+++ b/resources/views/components/modals/curator-panel.blade.php
@@ -189,19 +189,52 @@
                     </div>
 
                     <div class="flex items-center justify-start mt-auto gap-3 py-3 px-4 border-t border-gray-300 bg-gray-200 dark:border-gray-800 dark:bg-black/10">
-                        @can('create', \Awcodes\Curator\Models\Media::class)
-                            @if (count($selected) !== 1)
+                        @php
+                            use Illuminate\Support\Facades\Gate;
+                            use Awcodes\Curator\Models\Media;
+                            use Illuminate\Support\Arr;
+
+                            // Checks for the 'create' ability.
+                            function canCreateMedia() {
+                                // Create a dummy instance for checking the policy.
+                                $dummy = new Media();
+                                $policy = Gate::getPolicyFor($dummy);
+                                // If no policy is registered, allow the action.
+                                if (is_null($policy)) {
+                                    return true;
+                                }
+                                return Gate::allows('create', Media::class);
+                            }
+
+                            // Checks for the 'update' ability on a specific media instance.
+                            function canUpdateMedia($media) {
+                                $policy = Gate::getPolicyFor($media);
+                                if (is_null($policy)) {
+                                    return true;
+                                }
+                                return Gate::allows('update', $media);
+                            }
+
+                            // Retrieve the media instance if exactly one item is selected.
+                            $media = null;
+                            if (count($selected) === 1) {
+                                $first = Arr::first($this->selected);
+                                $media = $first ? App::make(Media::class)->find($first['id']) : null;
+                            }
+                        @endphp
+                        @if (count($selected) !== 1)
+                            @if (canCreateMedia())
                                 <div>
                                     {{ $this->addFilesAction }}
                                     {{ $this->addInsertFilesAction }}
                                 </div>
                             @endif
-                        @endcan
+                        @endif
                         @if (count($selected) === 1)
                             <div class="flex gap-3">
-                                @can('update', App::make(\Awcodes\Curator\Models\Media::class)->find(Arr::first($this->selected)['id']))
+                                @if ($media && canUpdateMedia($media))
                                     {{ $this->updateFileAction }}
-                                @endcan
+                                @endif
                                 {{ $this->cancelEditAction }}
                             </div>
                         @endif

--- a/resources/views/components/modals/curator-panel.blade.php
+++ b/resources/views/components/modals/curator-panel.blade.php
@@ -199,7 +199,9 @@
                         @endcan
                         @if (count($selected) === 1)
                             <div class="flex gap-3">
-                                {{ $this->updateFileAction }}
+                                @can('update', App::make(\Awcodes\Curator\Models\Media::class)->find(Arr::first($this->selected)['id']))
+                                    {{ $this->updateFileAction }}
+                                @endcan
                                 {{ $this->cancelEditAction }}
                             </div>
                         @endif

--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -2,29 +2,30 @@
 
 namespace Awcodes\Curator\Components\Modals;
 
-use Awcodes\Curator\Components\Forms\Uploader;
-use Awcodes\Curator\Models\Media;
-use Awcodes\Curator\PathGenerators\Contracts\PathGenerator;
-use Awcodes\Curator\Resources\MediaResource;
 use Closure;
 use Exception;
+use Livewire\Component;
+use Filament\Forms\Form;
+use Illuminate\Support\Arr;
+use Livewire\Attributes\On;
 use Filament\Actions\Action;
-use Filament\Actions\Concerns\InteractsWithActions;
-use Filament\Actions\Contracts\HasActions;
+use Livewire\WithPagination;
+use Awcodes\Curator\Models\Media;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\App;
 use Filament\Forms\Components\Group;
+use Illuminate\Support\Facades\Gate;
+use Filament\Forms\Contracts\HasForms;
+use Illuminate\Support\Facades\Storage;
+use Filament\Notifications\Notification;
+use Filament\Actions\Contracts\HasActions;
+use Awcodes\Curator\Resources\MediaResource;
+use Awcodes\Curator\Components\Forms\Uploader;
 use Filament\Forms\Components\View as FormView;
 use Filament\Forms\Concerns\InteractsWithForms;
-use Filament\Forms\Contracts\HasForms;
-use Filament\Forms\Form;
-use Filament\Notifications\Notification;
-use Illuminate\Contracts\View\View;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Storage;
-use Livewire\Attributes\On;
-use Livewire\Component;
-use Livewire\WithPagination;
+use Filament\Actions\Concerns\InteractsWithActions;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use Awcodes\Curator\PathGenerators\Contracts\PathGenerator;
 
 class CuratorPanel extends Component implements HasActions, HasForms
 {
@@ -154,7 +155,7 @@ class CuratorPanel extends Component implements HasActions, HasForms
         return $form
             ->schema([
                 Uploader::make('files_to_add')
-                    ->visible(fn () => count($this->selected) !== 1)
+                    ->visible(fn () => count($this->selected) !== 1 && Gate::allows('create', App::make(Media::class)) )
                     ->hiddenLabel()
                     ->required()
                     ->multiple()
@@ -181,7 +182,7 @@ class CuratorPanel extends Component implements HasActions, HasForms
                             'actions' => array_filter([
                                 $this->viewAction(),
                                 $this->downloadAction(),
-                                ($file && isset($file["id"]) && \Illuminate\Support\Facades\Gate::allows('delete', App::make(Media::class)->find($file["id"])))
+                                ($file && isset($file["id"]) && Gate::allows('delete', App::make(Media::class)->find($file["id"])))
                                     ? $this->destroyAction()
                                     : null,
                             ]),

--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -175,19 +175,29 @@ class CuratorPanel extends Component implements HasActions, HasForms
                     ->imageResizeTargetWidth($this->imageResizeTargetWidth)
                     ->imageResizeTargetHeight($this->imageResizeTargetHeight)
                     ->storeFileNamesIn('originalFilenames'),
-                Group::make([
-                    FormView::make('preview')
-                        ->view('curator::components.forms.edit-preview', [
-                            'file' => $file = Arr::first($this->selected),
-                            'actions' => array_filter([
-                                $this->viewAction(),
-                                $this->downloadAction(),
-                                ($file && isset($file["id"]) && Gate::allows('delete', App::make(Media::class)->find($file["id"])))
-                                    ? $this->destroyAction()
-                                    : null,
+                    Group::make([
+                        FormView::make('preview')
+                            ->view('curator::components.forms.edit-preview', [
+                                'file' => $file = Arr::first($this->selected), // Assign $file here
+                                'actions' => array_filter([
+                                    $this->viewAction(),
+                                    $this->downloadAction(),
+                                    ($file && isset($file["id"]) && Gate::allows('delete', App::make(Media::class)->find($file["id"])))
+                                        ? $this->destroyAction()
+                                        : null,
+                                ]),
                             ]),
-                        ]),
-                    ...App::make(MediaResource::class)->getAdditionalInformationFormSchema(),
+                        ...collect(App::make(MediaResource::class)->getAdditionalInformationFormSchema())
+                            ->map(function ($component) use ($file) { // Capture $file
+                                $media = ($file && isset($file['id'])) 
+                                    ? App::make(Media::class)->find($file['id'])
+                                    : null;
+        
+                                return $component->disabled(
+                                    !$media || !Gate::allows('update', $media)
+                                );
+                            })
+                            ->all(),
                 ])->visible(fn () => filled($this->selected) && count($this->selected) === 1),
             ])->statePath('data');
     }

--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -177,12 +177,14 @@ class CuratorPanel extends Component implements HasActions, HasForms
                 Group::make([
                     FormView::make('preview')
                         ->view('curator::components.forms.edit-preview', [
-                            'file' => Arr::first($this->selected),
-                            'actions' => [
+                            'file' => $file = Arr::first($this->selected),
+                            'actions' => array_filter([
                                 $this->viewAction(),
                                 $this->downloadAction(),
-                                $this->destroyAction(),
-                            ],
+                                ($file && isset($file["id"]) && \Illuminate\Support\Facades\Gate::allows('delete', App::make(Media::class)->find($file["id"])))
+                                    ? $this->destroyAction()
+                                    : null,
+                            ]),
                         ]),
                     ...App::make(MediaResource::class)->getAdditionalInformationFormSchema(),
                 ])->visible(fn () => filled($this->selected) && count($this->selected) === 1),

--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -155,7 +155,12 @@ class CuratorPanel extends Component implements HasActions, HasForms
         return $form
             ->schema([
                 Uploader::make('files_to_add')
-                    ->visible(fn () => count($this->selected) !== 1 && Gate::allows('create', App::make(Media::class)) )
+                    ->visible(fn () => count($this->selected) !== 1 &&
+                    (
+                        // Fallback: allow if no policy is registered, otherwise check 'create'
+                        is_null(Gate::getPolicyFor(App::make(Media::class))) ||
+                        Gate::allows('create', App::make(Media::class))
+                    ))
                     ->hiddenLabel()
                     ->required()
                     ->multiple()
@@ -182,19 +187,29 @@ class CuratorPanel extends Component implements HasActions, HasForms
                                 'actions' => array_filter([
                                     $this->viewAction(),
                                     $this->downloadAction(),
-                                    ($file && isset($file["id"]) && Gate::allows('delete', App::make(Media::class)->find($file["id"])))
+                                    (
+                                        $file &&
+                                        isset($file["id"]) &&
+                                        ($media = App::make(Media::class)->find($file["id"])) &&
+                                        (
+                                            // Fallback: allow if no policy is registered, otherwise check 'delete'
+                                            is_null(Gate::getPolicyFor($media)) ||
+                                            Gate::allows('delete', $media)
+                                        )
+                                    )
                                         ? $this->destroyAction()
                                         : null,
                                 ]),
                             ]),
                         ...collect(App::make(MediaResource::class)->getAdditionalInformationFormSchema())
                             ->map(function ($component) use ($file) { // Capture $file
-                                $media = ($file && isset($file['id'])) 
-                                    ? App::make(Media::class)->find($file['id'])
-                                    : null;
-        
+                                $media = ($file && isset($file['id']))
+                                ? App::make(Media::class)->find($file['id'])
+                                : null;
+    
                                 return $component->disabled(
-                                    !$media || !Gate::allows('update', $media)
+                                    // Disable if there is no media OR if a policy exists and update is not allowed.
+                                    !$media || (!is_null(Gate::getPolicyFor($media)) && !Gate::allows('update', $media))
                                 );
                             })
                             ->all(),

--- a/src/Resources/MediaResource/ListMedia.php
+++ b/src/Resources/MediaResource/ListMedia.php
@@ -2,13 +2,14 @@
 
 namespace Awcodes\Curator\Resources\MediaResource;
 
-use Awcodes\Curator\Actions\MultiUploadAction;
-use Awcodes\Curator\CuratorPlugin;
 use Exception;
-use Filament\Actions\Action;
-use Filament\Actions\CreateAction;
-use Filament\Resources\Pages\ListRecords;
 use Illuminate\Support\Str;
+use Filament\Actions\Action;
+use Awcodes\Curator\CuratorPlugin;
+use Filament\Actions\CreateAction;
+use Illuminate\Support\Facades\Gate;
+use Filament\Resources\Pages\ListRecords;
+use Awcodes\Curator\Actions\MultiUploadAction;
 
 class ListMedia extends ListRecords
 {
@@ -63,7 +64,13 @@ class ListMedia extends ListRecords
                     $livewire->dispatch('changeLayoutView');
                 }),
             MultiUploadAction::make()
-                ->authorize('create', $this->getModel()),
+                ->authorize(function () {
+                    $model = $this->getModel();
+                    if (! Gate::getPolicyFor($model)) {
+                        return true;
+                    }
+                    return Gate::allows('create', $model);
+                }),
             CreateAction::make()
                 ->label(fn (): string => trans('filament-actions::create.single.label', ['label' => CuratorPlugin::get()->getLabel()])),
         ];

--- a/src/Resources/MediaResource/ListMedia.php
+++ b/src/Resources/MediaResource/ListMedia.php
@@ -62,7 +62,8 @@ class ListMedia extends ListRecords
                 ->action(function ($livewire): void {
                     $livewire->dispatch('changeLayoutView');
                 }),
-            MultiUploadAction::make(),
+            MultiUploadAction::make()
+                ->authorize('create', $this->getModel()),
             CreateAction::make()
                 ->label(fn (): string => trans('filament-actions::create.single.label', ['label' => CuratorPlugin::get()->getLabel()])),
         ];


### PR DESCRIPTION
Detail: #570

Repository for testing this issue:
https://github.com/lyrihkaesa/filament-plugin-tester

---

| `CuratorPanel.php`, `curator-panel.blade.php`, `picker.blade.php` |
| --- |
| ![MediaPickerModalPanel](https://github.com/user-attachments/assets/257d3fa5-7d8a-4228-bbb5-29dd2bf017e0) |

- `update()` policy > `picker.blade.php`
- `create()`, `update()`, `delete()` policy > `CuratorPanel.php` and `curator-panel.blade.php`


| `MediaResource/ListMedia.php` |
| --- |
| ![MediaResource](https://github.com/user-attachments/assets/62ffa2d4-8c7a-4636-bbb3-540cd6d78297) |

- `create()` policy > `MultiUploadAction::make()`
  Maybe make spesific policy? like `createMultiple()` ?
- `deleteAny()` policy > `DeleteBulkAction::make()`

---

| add policy delete & update in modal panel: | add policy create in modal panel |
| --- | --- |
| ![delete and update](https://github.com/user-attachments/assets/51dba42c-599c-4faa-946d-f5e54a66ed23) | ![create](https://github.com/user-attachments/assets/59f29362-05ab-46fb-9a7a-89073241398e) |

| add policy update in picker |
| --- |
| ![image](https://github.com/user-attachments/assets/f8e54084-1518-4cf2-ab25-fd13c60d4853) |

| add policy create in ListMedia Resource |
| --- |
| ![image](https://github.com/user-attachments/assets/2a5669eb-2085-46b9-83aa-bb8342cb1651) |
