### PR TITLE
fix: if private, and not checking existance, use temporaryUrl

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -40,26 +40,21 @@ class Media extends Model
     {
         return Attribute::make(
             get: function () {
-                if (! config('curator.should_check_exists', true)) {
-                    return Storage::disk($this->disk)->url($this->path);
-                }
-
-                if (Storage::disk($this->disk)->exists($this->path) === false) {
+                if (config('curator.should_check_exists', true) && Storage::disk($this->disk)->exists($this->path) === false) {
                     return '';
                 }
 
                 try {
-                    $isPrivate = Storage::disk($this->disk)->getVisibility($this->path) === 'private';
+                    $isPrivate = config('curator.visibility','public') === 'private' || Storage::disk($this->disk)->getVisibility($this->path) === 'private ';
                 } catch (\Throwable) {
                     // ACL not supported on Storage Bucket, Laravel only throws exception here so need to be careful.
-                    // so we assume it's private
-                    $isPrivate = config(sprintf('filesystems.disks.%s.visibility', $this->disk)) !== 'public';
+                    // so we assume it's private $isPrivate = config(sprintf('filesystems.disks.%s.visibility', $this->disk)) !== 'public';
                 }
 
-                return $isPrivate ? Storage::disk($this->disk)->temporaryUrl(
-                    $this->path,
-                    now()->addMinutes(5)
-                ) : Storage::disk($this->disk)->url($this->path);
+                    return $isPrivate ? Storage::disk($this->disk)->temporaryUrl(
+                        $this->path,
+                        now()->addMinutes(5)
+                    ) : Storage::disk($this->disk)->url($this->path);
             },
         );
     }


### PR DESCRIPTION
when using S3 - private and setting config for checking existance to false, it returns the unsigned url,

this patch improves the url function to work as follows:

if existance check is true and file does not exist, return empty string,
check if config says image should be private and if it is public only then get the image acl

