### PR TITLE
add image on the is_media_resizable array

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -14,7 +14,7 @@ if (! function_exists('is_media_resizable')) {
             return false;
         }
 
-        return in_array($type, ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/bmp']);
+        return in_array($type, ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/bmp', 'image']);
     }
 }
 


### PR DESCRIPTION
I'm uploading my asset to Cloudinary, and the file type of the image is "image" only, without, for example, "image/png" or "image/jpg," etc. 

Is it possible to merge this PR?

For your context, on the livewire temporary uploaded file, I also stored them on Cloudinary; that's why the file format is a little bit different.