### PR TITLE
Handle complex exif containing binary / embedded arrays

### DIFF
--- a/src/Actions/MultiUploadAction.php
+++ b/src/Actions/MultiUploadAction.php
@@ -40,15 +40,6 @@ class MultiUploadAction extends Action
             ])
             ->action(function ($data) {
                 foreach ($data['files'] as $item) {
-                    // Fix malformed utf-8 characters
-                    if (! empty($item['exif'])) {
-                        array_walk_recursive($item['exif'], function (&$entry) {
-                            if (! mb_detect_encoding($entry, 'utf-8', true)) {
-                                $entry = mb_convert_encoding($entry, 'utf-8');
-                            }
-                        });
-                    }
-
                     $item['title'] = pathinfo($data['originalFilename'][$item['path']] ?? null, PATHINFO_FILENAME);
 
                     tap(

--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -549,15 +549,6 @@ class CuratorPanel extends Component implements HasActions, HasForms
         $media = [];
 
         foreach ($formData['files_to_add'] as $item) {
-            // Fix malformed utf-8 characters
-            if (! empty($item['exif'])) {
-                array_walk_recursive($item['exif'], function (&$entry) {
-                    if (! mb_detect_encoding($entry, 'utf-8', true)) {
-                        $entry = mb_convert_encoding($entry, 'utf-8');
-                    }
-                });
-            }
-
             $item['title'] = pathinfo($formData['originalFilenames'][$item['path']] ?? null, PATHINFO_FILENAME);
 
             $media[] = tap(

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -198,20 +198,20 @@ class Media extends Model
     /**
      * Detect strings that are (at least mostly) binary
      */
-    protected function isMostlyBinary($string)
+    protected function isMostlyBinary(mixed $value): bool
     {
-        if (! is_string($string)) {
+        if (! is_string($value)) {
             return false;
         }
 
         // check for invalid encoding (likely binary)
-        if (! mb_detect_encoding($string, 'UTF-8', true)) {
+        if (! mb_detect_encoding($value, 'UTF-8', true)) {
             return true;
         }
 
         // remove printable UTF-8 chars and see how much is left
-        $nonPrintable = preg_replace('/[[:print:]\s]/u', '', $string);
+        $nonPrintable = preg_replace('/[[:print:]\s]/u', '', $value);
 
-        return strlen($nonPrintable) > (strlen($string) * 0.1); // allow a few non-printable characters
+        return strlen($nonPrintable) > (strlen($value) * 0.1); // allow a few non-printable characters
     }
 }

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -121,22 +121,13 @@ class Media extends Model
     }
 
     /**
-     * Cast exif data safely, dealing with any non-utf8 characters, strip any embedded objects/arrays
+     * Cast exif data safely, dealing with any non-utf8 characters
      */
     protected function exif(): Attribute
     {
         return Attribute::make(
-            get: fn ($value) => $value ? json_decode($value, true) : null,
-            set: function ($value) {
-                if (! $value) {
-                    return null;
-                }
-
-                return collect($value)
-                    ->filter(fn ($item) => ! is_array($item) && ! is_object($item) && ! $this->isMostlyBinary($item))
-                    ->map(fn ($item) => is_string($item) ? mb_convert_encoding($item, 'UTF-8', 'UTF-8') : $item)
-                    ->toJson();
-            }
+            get: fn ($value) => json_decode($this->decodeExif($value), true),
+            set: fn ($value) => json_encode($this->encodeExif($value)),
         );
     }
 
@@ -196,9 +187,45 @@ class Media extends Model
     }
 
     /**
-     * Detect strings that are (at least mostly) binary
+     * Recursively encode exif data safely, dealing with any non-utf8 characters
      */
-    protected function isMostlyBinary(mixed $value): bool
+    protected function encodeExif(mixed $value): mixed
+    {
+        if (! $value) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            return array_map(fn ($item) => $this->encodeExif($item), $value);
+        }
+
+        return $this->needsBase64($value) ? self::BASE64_PREFIX.base64_encode($value) : $value;
+    }
+
+    /**
+     * Decode exif data safely, dealing with any base64 encoded strings
+     */
+    protected function decodeExif(mixed $value): mixed
+    {
+        if (! $value) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            return array_map(fn ($item) => $this->decodeExif($item), $value);
+        }
+
+        if (str_starts_with($value, self::BASE64_PREFIX)) {
+            return base64_decode(substr($value, strlen(self::BASE64_PREFIX)));
+        }
+
+        return $value;
+    }
+
+    /**
+     * Detect strings that should be encoded as base64
+     */
+    protected function needsBase64(mixed $value): bool
     {
         if (! is_string($value)) {
             return false;
@@ -209,9 +236,9 @@ class Media extends Model
             return true;
         }
 
-        // remove printable UTF-8 chars and see how much is left
+        // encode as base64 if there are any non-printable characters
         $nonPrintable = preg_replace('/[[:print:]\s]/u', '', $value);
 
-        return strlen($nonPrintable) > (strlen($value) * 0.1); // allow a few non-printable characters
+        return strlen($nonPrintable) > strlen($value);
     }
 }

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -50,7 +50,6 @@ class Media extends Model
         'height' => 'integer',
         'size' => 'integer',
         'curations' => 'array',
-        'exif' => 'array',
     ];
 
     protected $appends = [
@@ -121,6 +120,26 @@ class Media extends Model
         );
     }
 
+    /**
+     * Cast exif data safely, dealing with any non-utf8 characters, strip any embedded objects/arrays
+     */
+    protected function exif(): Attribute
+    {
+        return Attribute::make(
+            get: fn ($value) => $value ? json_decode($value, true) : null,
+            set: function ($value) {
+                if (! $value) {
+                    return null;
+                }
+
+                return collect($value)
+                    ->filter(fn ($item) => ! is_array($item) && ! is_object($item) && ! $this->isMostlyBinary($item))
+                    ->map(fn ($item) => is_string($item) ? mb_convert_encoding($item, 'UTF-8', 'UTF-8') : $item)
+                    ->toJson();
+            }
+        );
+    }
+
     public function getPrettyName(): string
     {
         if (filled($this->title)) {
@@ -174,5 +193,25 @@ class Media extends Model
     public function hasCuration(string $key): bool
     {
         return filled($this->getCuration($key));
+    }
+
+    /**
+     * Detect strings that are (at least mostly) binary
+     */
+    protected function isMostlyBinary($string)
+    {
+        if (! is_string($string)) {
+            return false;
+        }
+
+        // check for invalid encoding (likely binary)
+        if (! mb_detect_encoding($string, 'UTF-8', true)) {
+            return true;
+        }
+
+        // remove printable UTF-8 chars and see how much is left
+        $nonPrintable = preg_replace('/[[:print:]\s]/u', '', $string);
+
+        return strlen($nonPrintable) > (strlen($string) * 0.1); // allow a few non-printable characters
     }
 }

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -62,6 +62,11 @@ class Media extends Model
         'pretty_name',
     ];
 
+    /**
+     * A prefix to identify base64 encoded strings in exif data
+     */
+    protected const BASE64_PREFIX = 'encoded@base64:';
+
     protected function url(): Attribute
     {
         return Attribute::make(

--- a/src/Observers/MediaObserver.php
+++ b/src/Observers/MediaObserver.php
@@ -21,15 +21,6 @@ class MediaObserver
                     } else {
                         $media->{$k} = $v->toString();
                     }
-                } elseif ($k === 'exif' && is_array($v)) {
-                    // Fix malformed utf-8 characters
-                    array_walk_recursive($v, function (&$entry) {
-                        if (! mb_detect_encoding($entry, 'utf-8', true)) {
-                            $entry = mb_convert_encoding($entry, 'utf-8');
-                        }
-                    });
-
-                    $media->{$k} = $v;
                 } else {
                     $media->{$k} = $v;
                 }


### PR DESCRIPTION
This PR proposes a fix to https://github.com/awcodes/filament-curator/issues/602 - it is working well for me.

To summarise, if you upload a new image **when editing** a Media entry you receive an error if it contains binary. It also will store embedded arrays of data but fail to render them anywhere in the UI correctly.

This has been previously addressed here: https://github.com/awcodes/filament-curator/pull/168 (presumably for the 'create a new media entry' screen) - but that fix fails to address all areas where the situation could occur. A better fix is to address this at a model casting level - so the model can always save if it contains problematic exif regardless of where in the code base the save was attempted.

My proposed fix is pretty ruthless - stripping everything that could throw an error, **as well as anything that the UI fails to render anyway**:
1. binary data
2. arrays
3. objects

If for some reason you still wanted to support arrays & objects in the exif data, you would need to modify the proposed `exif` function to recurse through any such value instead of filtering them out.

As this fix deals with the problem on a model level, I would expect it fixes the issue anywhere that the problem occurs & probably makes the fix in https://github.com/awcodes/filament-curator/pull/168 redundant. I have tested this & it appears to be the case - so this PR also removes that fix.