### PR TITLE
Allow custom navigation badge count in MediaResource by extracting badge count logic

### DIFF
--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -71,14 +71,20 @@ class MediaResource extends Resource
         return config('curator.resources.cluster');
     }
 
+    protected static function getNavigationBadgeCount(): int
+    {
+        if (Filament::hasTenancy() && Config::get('curator.is_tenant_aware')) {
+            return static::getEloquentQuery()
+                ->where(Config::get('curator.tenant_ownership_relationship_name') . '_id', Filament::getTenant()->id)
+                ->count();
+        }
+        return static::getModel()::count();
+    }
+
     public static function getNavigationBadge(): ?string
     {
-        return CuratorPlugin::get()->getNavigationCountBadge() ?
-            (Filament::hasTenancy() && Config::get('curator.is_tenant_aware') ?
-                static::getEloquentQuery()
-                    ->where(Config::get('curator.tenant_ownership_relationship_name') . '_id', Filament::getTenant()->id)
-                    ->count()
-            : number_format(static::getModel()::count()))
+        return CuratorPlugin::get()->getNavigationCountBadge()
+            ? number_format(static::getNavigationBadgeCount())
             : null;
     }
 


### PR DESCRIPTION
This change extracts the navigation badge count logic into a protected static method, making it easier for custom resources to override the badge count while preserving support for tenancy and plugin settings.