### PR TITLE
Pin cropperjs to version 1.6.2 to prevent breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In an effort to align with Filament's theming methodology you will need to use a
 You will also need to add cropper.js.
 
 ```bash
-npm install -D cropperjs
+npm install -D cropperjs@1.6.2
 ```
 
 1. Import the plugin's stylesheet and cropperjs' stylesheet into your theme's css file.


### PR DESCRIPTION
# Pin cropperjs to version 1.6.2 to prevent breaking changes

## Problem

The current installation instructions for cropperjs don't specify a version, which means users will get the latest version (v2.x) by default. However, cropperjs v2 introduced breaking changes including:

- Removal of CSS files from the `dist` folder
- Structural changes that break the current integration

This causes installation issues for users following the documentation, as the required CSS file (`cropperjs/dist/cropper.css`) is no longer available in v2.

## Solution

Pin the cropperjs dependency to version `1.6.2` (the last stable v1.x release) in the installation instructions. This ensures:

- ✅ CSS files remain available at the expected path
- ✅ Existing functionality continues to work
- ✅ Consistent behavior across installations
- ✅ No breaking changes for current users

## Changes

- Updated installation command from `npm install -D cropperjs` to `npm install -D cropperjs@1.6.2`

## Notes

This is a documentation-only change that prevents compatibility issues without requiring any code modifications. Future updates can evaluate migrating to cropperjs v2 when the integration can be properly updated to handle the breaking changes.

---

*P.S. Thank you @awcodes for all your amazing open source contributions to the Filament ecosystem! Your packages like Curator make building Laravel applications so much more enjoyable. 🙏*
![image](https://github.com/user-attachments/assets/47fb24ec-65ec-4fef-b808-40f3733d2883)
