### PR TITLE
Enable windows and mac multiselect option

### DIFF
--- a/resources/views/components/modals/curator-panel.blade.php
+++ b/resources/views/components/modals/curator-panel.blade.php
@@ -3,7 +3,7 @@
         handleItemClick: function (mediaId = null, event) {
             if (! mediaId) return;
 
-            if ($wire.isMultiple && event && event.{{ config('curator.multi_select_key') }}) {
+            if ($wire.isMultiple && event && event.metaKey || event.ctrlKey) {
                 if (this.isSelected(mediaId)) {
                     let toRemove = Object.values($wire.selected).find(obj => obj.id == mediaId)
                     $wire.removeFromSelection(toRemove.id);

--- a/resources/views/components/modals/curator-panel.blade.php
+++ b/resources/views/components/modals/curator-panel.blade.php
@@ -3,7 +3,7 @@
         handleItemClick: function (mediaId = null, event) {
             if (! mediaId) return;
 
-            if ($wire.isMultiple && event && event.metaKey || event.ctrlKey) {
+            if ($wire.isMultiple && event && (event.metaKey || event.ctrlKey)) {
                 if (this.isSelected(mediaId)) {
                     let toRemove = Object.values($wire.selected).find(obj => obj.id == mediaId)
                     $wire.removeFromSelection(toRemove.id);


### PR DESCRIPTION
This pull request will enable both multiselect options when using multi_select_key = 'metaKey' system's multiselect from not working. I've added the `event.metaKey || event.ctrlKey.`