### PR TITLE
fix: allow title to also be used in table searches. Closes #606

### DIFF
--- a/src/Resources/MediaResource.php
+++ b/src/Resources/MediaResource.php
@@ -250,7 +250,7 @@ class MediaResource extends Resource
                 ->size(40),
             Tables\Columns\TextColumn::make('name')
                 ->label(trans('curator::tables.columns.name'))
-                ->searchable()
+                ->searchable(['name', 'title'])
                 ->sortable(),
             Tables\Columns\TextColumn::make('ext')
                 ->label(trans('curator::tables.columns.ext'))
@@ -282,7 +282,7 @@ class MediaResource extends Resource
             Tables\Columns\TextColumn::make('name')
                 ->label(trans('curator::tables.columns.name'))
                 ->extraAttributes(['class' => 'hidden'])
-                ->searchable()
+                ->searchable(['name', 'title'])
                 ->sortable(),
             Tables\Columns\TextColumn::make('ext')
                 ->label(trans('curator::tables.columns.ext'))


### PR DESCRIPTION
I originally added a new hidden "title" column and new translations for it, causing a lot of touched files. But reading the docs, it looks like you can just pass an array of columns. This seems like it is meant for computed columns, but it works perfectly fine here!

The other option to reduce the number of changes would be passing a query to the searchable closure, but that would be the same thing as this solution.

![Screen Shot 2025-06-06 at 9 19 27 AM](https://github.com/user-attachments/assets/668b757d-d290-4405-8754-c900e7966986)
![Screen Shot 2025-06-06 at 9 19 37 AM](https://github.com/user-attachments/assets/a1f2ddce-a255-4dea-a97d-adc07bd4f140)
![Screen Shot 2025-06-06 at 9 19 45 AM](https://github.com/user-attachments/assets/11d1aed2-0dee-4568-b760-70cd9b7b1ef1)
![Screen Shot 2025-06-06 at 9 19 53 AM](https://github.com/user-attachments/assets/e6c31682-fbda-4803-9d12-5264276c950c)
![Screen Shot 2025-06-06 at 9 20 00 AM](https://github.com/user-attachments/assets/2494b285-8628-476d-9d0c-e95334f12961)

One thing that might be worth changing/tweaking is the fact that the table shows a "name" column, but the grid shows the "title" column. So there is a disconnect there. 
