### PR TITLE
fix(curation): Correct image flip direction

### DIFF
--- a/src/Components/Modals/CuratorCuration.php
+++ b/src/Components/Modals/CuratorCuration.php
@@ -47,11 +47,11 @@ class CuratorCuration extends Component
         }
 
         if ($data['scaleX'] === -1) {
-            $image->flip('v');
+            $image->flip('h');
         }
 
         if ($data['scaleY'] === -1) {
-            $image->flip('h');
+            $image->flip('v');
         }
 
         $image->crop($data['width'], $data['height'], $data['x'], $data['y'])


### PR DESCRIPTION
fix(curation): Align image flip logic with Cropper.js axes

The previous implementation incorrectly mapped the flip axes from the Cropper.js data, causing the final image to be flipped vertically when a horizontal flip was intended, and vice-versa.

- Maps `scaleX: -1` to `->flip('h')` for a horizontal flip.
- Maps `scaleY: -1` to `->flip('v')` for a vertical flip.

@awcodes This ensures the image processing accurately reflects the transformation applied by the user in the curation modal.