### PR TITLE
Register filament resource from config if set

### DIFF
--- a/src/CuratorPlugin.php
+++ b/src/CuratorPlugin.php
@@ -51,7 +51,7 @@ class CuratorPlugin implements Plugin
     {
         $panel
             ->resources([
-                MediaResource::class,
+                config('curator.resource.resource', MediaResource::class),
             ]);
     }
 


### PR DESCRIPTION
Fixes issue with duplicate resources registered in menu if using a custom MediaResource with a different NavigationGroup. 