### PR TITLE
FIX: Customizing MediaForm schema to support overriding getAdditional…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ phpunit.xml
 phpstan.neon
 testbench.yaml
 vendor
+.history

--- a/src/Components/Modals/Concerns/HasBreadcrumbs.php
+++ b/src/Components/Modals/Concerns/HasBreadcrumbs.php
@@ -31,7 +31,8 @@ trait HasBreadcrumbs
         ? $dirs[$currentDir] 
         : (is_string($currentDir) ? ['label' => $currentDir, 'path' => $currentDir] : $currentDir); 
 
-        if ($item['parent_path']) {
+        $crumbs = [];
+        if (isset($item['parent_path']) && $item['parent_path']) {
             $crumbs = $this->generateBreadcrumbs($dirs[$item['parent_path']], $dirs);
         }
 

--- a/src/Components/Modals/Concerns/HasBreadcrumbs.php
+++ b/src/Components/Modals/Concerns/HasBreadcrumbs.php
@@ -27,7 +27,9 @@ trait HasBreadcrumbs
             return [];
         }
 
-        $item = is_string($currentDir) ? $dirs[$currentDir] : $currentDir;
+        $item = is_string($currentDir) && array_key_exists($currentDir, $dirs) 
+        ? $dirs[$currentDir] 
+        : (is_string($currentDir) ? ['label' => $currentDir, 'path' => $currentDir] : $currentDir); 
 
         if ($item['parent_path']) {
             $crumbs = $this->generateBreadcrumbs($dirs[$item['parent_path']], $dirs);

--- a/src/Resources/Media/Schemas/MediaForm.php
+++ b/src/Resources/Media/Schemas/MediaForm.php
@@ -20,6 +20,7 @@ use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Schema;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\App;
 
 class MediaForm
 {
@@ -92,9 +93,7 @@ class MediaForm
                 Group::make()
                     ->schema([
                         Section::make(trans('curator::forms.sections.meta'))
-                            ->schema(
-                                static::getAdditionalInformationFormSchema()
-                            ),
+                            ->schema(App::make(config('curator.resource.schemas.form'))::getAdditionalInformationFormSchema()),
                     ])->columnSpan([
                         'md' => 'full',
                         'lg' => 1,


### PR DESCRIPTION
## FIX: Guarantee Schema Overriding/Inheritance for `MediaForm` Meta Fields

This PR addresses an issue where derived schemas were not correctly executed within `MediaForm::configure()`, preventing developers from overriding fields (like `alt`) or adding custom fields (like `alts_json`).

### The Problem

The static method call within `MediaForm::configure()` was being bypassed/ignored when a custom schema class was used (even when properly bound). This is likely due to the execution context failing to correctly resolve the derived class via Late Static Binding (LSP).

### The Solution

The fix explicitly resolves the target schema class from the **Curator Configuration** (`config('curator.resource.schemas.form')`) before invoking the required static method.

This ensures that the framework respects the developer's custom binding:

```php
// Suggested Fix in MediaForm.php (inside configure)
->schema(
    \Illuminate\Support\Facades\App::make(config('curator.resource.schemas.form'))::getAdditionalInformationFormSchema()
),
```

### This change:
Guarantees that the class specified in the curator.resource.schemas.form setting is used.
Fully enables developers to implement inheritance (e.g., CustomMediaForm extends MediaForm) and cleanly override getAdditionalInformationFormSchema() without conflicts, solving the issue of adding translatable fields.