### PR TITLE
feat: Add RichEditor integration for Filament v4

### DIFF
--- a/resources/js/richeditor-integration.js
+++ b/resources/js/richeditor-integration.js
@@ -1,0 +1,160 @@
+/**
+ * Filament Curator - RichEditor Integration
+ *
+ * Bridges Curator's media picker with Filament v4's RichEditor (TipTap).
+ * Uses Filament's native 'run-rich-editor-commands' event system.
+ */
+
+(function() {
+    'use strict';
+
+    // Singleton flag to prevent multiple initializations
+    if (window.__curatorRichEditorInitialized) {
+        return;
+    }
+    window.__curatorRichEditorInitialized = true;
+
+    // Store editor context when curator button is clicked
+    let savedKey = null;
+    let savedLivewireId = null;
+    let savedEditorSelection = null;
+
+    // Prevent duplicate insertions
+    let processing = false;
+
+    // Capture key, livewireId, and editorSelection when curator media button is clicked
+    document.addEventListener('click', function(e) {
+        const btn = e.target.closest('button');
+        if (!btn) return;
+
+        // Check if this is the curator media toolbar button
+        const wrapper = btn.closest('.fi-fo-rich-editor');
+        if (!wrapper) return;
+
+        // Find the Alpine element with x-data
+        const alpineEl = wrapper.querySelector('[x-data*="richEditorFormComponent"]');
+        if (!alpineEl) return;
+
+        // Extract key from x-data attribute
+        const xData = alpineEl.getAttribute('x-data') || '';
+        const keyMatch = xData.match(/key:\s*['"]([^'"]+)['"]/);
+        savedKey = keyMatch ? keyMatch[1] : null;
+
+        // Extract livewireId from closest wire:id element
+        const wireEl = wrapper.closest('[wire\\:id]');
+        savedLivewireId = wireEl?.getAttribute('wire:id');
+
+        // Capture editor selection directly from TipTap at click time
+        try {
+            const alpine = Alpine.$data(alpineEl);
+            if (alpine?.getEditor) {
+                const editor = alpine.getEditor();
+                if (editor?.state?.selection) {
+                    savedEditorSelection = {
+                        type: 'text',
+                        anchor: editor.state.selection.anchor,
+                        head: editor.state.selection.head
+                    };
+                }
+            }
+        } catch (err) {
+            // Fallback if Alpine data extraction fails
+            savedEditorSelection = { type: 'text', anchor: 1, head: 1 };
+        }
+    }, true);
+
+    function handleInsertMedia(event) {
+        // Prevent concurrent processing
+        if (processing) {
+            return;
+        }
+        processing = true;
+
+        try {
+            // Extract event data (handle Livewire array wrapper)
+            let data = event.detail;
+            if (Array.isArray(data)) data = data[0];
+
+            const { statePath, media } = data || {};
+            if (!statePath || !media) {
+                return;
+            }
+
+            // Get first media item
+            const items = Array.isArray(media) ? media : [media];
+            const item = items[0];
+            if (!item?.url) {
+                return;
+            }
+
+            // Use saved key and livewireId, or find them fresh
+            let key = savedKey;
+            let livewireId = savedLivewireId;
+            let editorSelection = savedEditorSelection;
+
+            if (!key || !livewireId) {
+                // Find the RichEditor component
+                const wrapper = document.querySelector('.fi-fo-rich-editor');
+                if (!wrapper) return;
+
+                const alpineEl = wrapper.querySelector('[x-data*="richEditorFormComponent"]');
+                if (!alpineEl) return;
+
+                const xData = alpineEl.getAttribute('x-data') || '';
+                const keyMatch = xData.match(/key:\s*['"]([^'"]+)['"]/);
+                key = keyMatch ? keyMatch[1] : null;
+
+                const wireEl = wrapper.closest('[wire\\:id]');
+                livewireId = wireEl?.getAttribute('wire:id');
+            }
+
+            if (!key || !livewireId) {
+                return;
+            }
+
+            // Use Filament's native run-rich-editor-commands event
+            // This properly handles selection restoration via setEditorSelection
+            window.dispatchEvent(new CustomEvent('run-rich-editor-commands', {
+                detail: {
+                    key: key,
+                    livewireId: livewireId,
+                    commands: [
+                        { name: 'focus' },
+                        {
+                            name: 'setImage',
+                            arguments: [{
+                                src: item.url,
+                                alt: item.alt || item.title || '',
+                                title: item.title || '',
+                                id: item.id || null,
+                            }]
+                        }
+                    ],
+                    // Use the selection captured at click time
+                    editorSelection: editorSelection || { type: 'text', anchor: 1, head: 1 }
+                }
+            }));
+
+            // Clear saved values
+            savedKey = null;
+            savedLivewireId = null;
+            savedEditorSelection = null;
+
+            // Close modal after a short delay
+            setTimeout(() => {
+                const closeBtn = document.querySelector('.fi-modal button[type="button"] svg[class*="x-mark"]')?.closest('button')
+                    || document.querySelector('.fi-modal [x-on\\:click*="close"]');
+                if (closeBtn) {
+                    closeBtn.click();
+                }
+            }, 100);
+
+        } finally {
+            // Reset processing flag after delay
+            setTimeout(() => { processing = false; }, 300);
+        }
+    }
+
+    // Initialize once
+    window.addEventListener('insert-media', handleInsertMedia);
+})();

--- a/src/CuratorServiceProvider.php
+++ b/src/CuratorServiceProvider.php
@@ -1,26 +1,19 @@
 <?php
 
-declare(strict_types=1);
-
 namespace Awcodes\Curator;
 
 use Awcodes\Curator\Commands\GenerateGlideTokenCommand;
 use Awcodes\Curator\Commands\InstallCommand;
-use Awcodes\Curator\Components\Modals\CuratorCuration;
-use Awcodes\Curator\Components\Modals\CuratorPanel;
 use Awcodes\Curator\Config\CurationManager;
 use Awcodes\Curator\Config\CuratorManager;
 use Awcodes\Curator\Config\GlideManager;
 use Awcodes\Curator\Models\Media;
-use Awcodes\Curator\Resources\Media\MediaResource;
-use Awcodes\Curator\Resources\Media\Pages\CreateMedia;
-use Awcodes\Curator\Resources\Media\Pages\EditMedia;
-use Awcodes\Curator\Resources\Media\Pages\ListMedia;
-use Awcodes\Curator\Resources\Media\Schemas\MediaForm;
-use Awcodes\Curator\Resources\Media\Tables\MediaTable;
+use Awcodes\Curator\Observers\MediaObserver;
+use Awcodes\Curator\Resources\MediaResource;
 use Awcodes\Curator\View\Components\Curation;
 use Awcodes\Curator\View\Components\Glider;
 use Filament\Support\Assets\AlpineComponent;
+use Filament\Support\Assets\Css;
 use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
 use Illuminate\Support\Facades\Blade;
@@ -47,19 +40,22 @@ class CuratorServiceProvider extends PackageServiceProvider
     {
         $this->app->scoped(
             abstract: CuratorManager::class,
-            concrete: fn (): CuratorManager => new CuratorManager(),
+            concrete: fn () => new CuratorManager(),
         );
 
         $this->app->scoped(
             abstract: GlideManager::class,
-            concrete: fn (): GlideManager => new GlideManager(),
+            concrete: fn () => new GlideManager(),
         );
 
         $this->app->scoped(
             abstract: CurationManager::class,
-            concrete: fn (): CurationManager => new CurationManager(),
+            concrete: fn () => new CurationManager(),
         );
+    }
 
+    public function packageBooted(): void
+    {
         $this->app->bind(
             abstract: Media::class,
             concrete: config('curator.model'),
@@ -71,42 +67,32 @@ class CuratorServiceProvider extends PackageServiceProvider
         );
 
         $this->app->bind(
-            abstract: CreateMedia::class,
+            abstract: MediaResource\CreateMedia::class,
             concrete: config('curator.resource.pages.create'),
         );
 
         $this->app->bind(
-            abstract: EditMedia::class,
+            abstract: MediaResource\EditMedia::class,
             concrete: config('curator.resource.pages.edit'),
         );
 
         $this->app->bind(
-            abstract: ListMedia::class,
+            abstract: MediaResource\ListMedia::class,
             concrete: config('curator.resource.pages.index'),
         );
 
-        $this->app->bind(
-            abstract: MediaForm::class,
-            concrete: config('curator.resource.schemas.form'),
-        );
+        app(abstract: Media::class)::observe(classes: MediaObserver::class);
 
-        $this->app->bind(
-            abstract: MediaTable::class,
-            concrete: config('curator.resource.tables.table'),
-        );
-    }
-
-    public function packageBooted(): void
-    {
-        Livewire::component(name: 'curator-panel', class: CuratorPanel::class);
-        Livewire::component(name: 'curator-curation', class: CuratorCuration::class);
+        Livewire::component(name: 'curator-panel', class: Components\Modals\CuratorPanel::class);
+        Livewire::component(name: 'curator-curation', class: Components\Modals\CuratorCuration::class);
 
         Blade::component(class: 'curator-glider', alias: Glider::class);
         Blade::component(class: 'curator-curation', alias: Curation::class);
 
         FilamentAsset::register([
-            AlpineComponent::make(id: 'curation', path: __DIR__.'/../resources/dist/curation.js'),
-            Js::make(id: 'richeditor-integration', path: __DIR__.'/../resources/js/richeditor-integration.js'),
+            AlpineComponent::make(id: 'curation', path: __DIR__ . '/../resources/dist/curation.js'),
+            Css::make(id: 'curator', path: __DIR__ . '/../resources/dist/curator.css')->loadedOnRequest(),
+            Js::make(id: 'richeditor-integration', path: __DIR__ . '/../resources/js/richeditor-integration.js'),
         ], package: 'awcodes/curator');
     }
 }

--- a/src/CuratorServiceProvider.php
+++ b/src/CuratorServiceProvider.php
@@ -1,19 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Awcodes\Curator;
 
 use Awcodes\Curator\Commands\GenerateGlideTokenCommand;
 use Awcodes\Curator\Commands\InstallCommand;
+use Awcodes\Curator\Components\Modals\CuratorCuration;
+use Awcodes\Curator\Components\Modals\CuratorPanel;
 use Awcodes\Curator\Config\CurationManager;
 use Awcodes\Curator\Config\CuratorManager;
 use Awcodes\Curator\Config\GlideManager;
 use Awcodes\Curator\Models\Media;
-use Awcodes\Curator\Observers\MediaObserver;
-use Awcodes\Curator\Resources\MediaResource;
+use Awcodes\Curator\Resources\Media\MediaResource;
+use Awcodes\Curator\Resources\Media\Pages\CreateMedia;
+use Awcodes\Curator\Resources\Media\Pages\EditMedia;
+use Awcodes\Curator\Resources\Media\Pages\ListMedia;
+use Awcodes\Curator\Resources\Media\Schemas\MediaForm;
+use Awcodes\Curator\Resources\Media\Tables\MediaTable;
 use Awcodes\Curator\View\Components\Curation;
 use Awcodes\Curator\View\Components\Glider;
 use Filament\Support\Assets\AlpineComponent;
-use Filament\Support\Assets\Css;
+use Filament\Support\Assets\Js;
 use Filament\Support\Facades\FilamentAsset;
 use Illuminate\Support\Facades\Blade;
 use Livewire\Livewire;
@@ -39,22 +47,19 @@ class CuratorServiceProvider extends PackageServiceProvider
     {
         $this->app->scoped(
             abstract: CuratorManager::class,
-            concrete: fn () => new CuratorManager(),
+            concrete: fn (): CuratorManager => new CuratorManager(),
         );
 
         $this->app->scoped(
             abstract: GlideManager::class,
-            concrete: fn () => new GlideManager(),
+            concrete: fn (): GlideManager => new GlideManager(),
         );
 
         $this->app->scoped(
             abstract: CurationManager::class,
-            concrete: fn () => new CurationManager(),
+            concrete: fn (): CurationManager => new CurationManager(),
         );
-    }
 
-    public function packageBooted(): void
-    {
         $this->app->bind(
             abstract: Media::class,
             concrete: config('curator.model'),
@@ -66,31 +71,42 @@ class CuratorServiceProvider extends PackageServiceProvider
         );
 
         $this->app->bind(
-            abstract: MediaResource\CreateMedia::class,
+            abstract: CreateMedia::class,
             concrete: config('curator.resource.pages.create'),
         );
 
         $this->app->bind(
-            abstract: MediaResource\EditMedia::class,
+            abstract: EditMedia::class,
             concrete: config('curator.resource.pages.edit'),
         );
 
         $this->app->bind(
-            abstract: MediaResource\ListMedia::class,
+            abstract: ListMedia::class,
             concrete: config('curator.resource.pages.index'),
         );
 
-        app(abstract: Media::class)::observe(classes: MediaObserver::class);
+        $this->app->bind(
+            abstract: MediaForm::class,
+            concrete: config('curator.resource.schemas.form'),
+        );
 
-        Livewire::component(name: 'curator-panel', class: Components\Modals\CuratorPanel::class);
-        Livewire::component(name: 'curator-curation', class: Components\Modals\CuratorCuration::class);
+        $this->app->bind(
+            abstract: MediaTable::class,
+            concrete: config('curator.resource.tables.table'),
+        );
+    }
+
+    public function packageBooted(): void
+    {
+        Livewire::component(name: 'curator-panel', class: CuratorPanel::class);
+        Livewire::component(name: 'curator-curation', class: CuratorCuration::class);
 
         Blade::component(class: 'curator-glider', alias: Glider::class);
         Blade::component(class: 'curator-curation', alias: Curation::class);
 
         FilamentAsset::register([
-            AlpineComponent::make(id: 'curation', path: __DIR__ . '/../resources/dist/curation.js'),
-            Css::make(id: 'curator', path: __DIR__ . '/../resources/dist/curator.css')->loadedOnRequest(),
+            AlpineComponent::make(id: 'curation', path: __DIR__.'/../resources/dist/curation.js'),
+            Js::make(id: 'richeditor-integration', path: __DIR__.'/../resources/js/richeditor-integration.js'),
         ], package: 'awcodes/curator');
     }
 }

--- a/src/RichEditor/CuratorMediaAction.php
+++ b/src/RichEditor/CuratorMediaAction.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Awcodes\Curator\RichEditor;
+
+use Awcodes\Curator\Models\Media;
+use Filament\Actions\Action;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\RichEditor\RichEditorTool;
+use Filament\Support\Enums\Width;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
+
+class CuratorMediaAction extends Action
+{
+    /**
+     * Get the toolbar button for the RichEditor.
+     */
+    public static function tool(): RichEditorTool
+    {
+        return RichEditorTool::make('curatorMedia')
+            ->label(trans('curator::views.picker.button'))
+            ->icon(Heroicon::Photo)
+            ->action(arguments: '{ src: $getEditor().getAttributes(\'image\')?.src, id: $getEditor().getAttributes(\'image\')?.id, alt: $getEditor().getAttributes(\'image\')?.alt }')
+            ->activeKey('image');
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this
+            ->arguments([
+                'src' => '',
+                'id' => null,
+                'alt' => null,
+            ])
+            ->modalHeading(trans('curator::views.panel.heading'))
+            ->modalSubmitAction(false)
+            ->modalCancelAction(false)
+            ->modalCloseButton(false)
+            ->modalWidth(Width::Screen)
+            ->modalContent(function (RichEditor $component, array $arguments): View {
+                return view('curator::components.modals.curator-panel', [
+                    'key' => $component->getKey(),
+                    'settings' => [
+                        'acceptedFileTypes' => $component->getFileAttachmentsAcceptedFileTypes() ?? ['image/*'],
+                        'defaultSort' => 'desc',
+                        'directory' => config('curator.default_directory') ?? '',
+                        'diskName' => config('curator.default_disk', 'public'),
+                        'imageCropAspectRatio' => null,
+                        'imageResizeMode' => null,
+                        'imageResizeTargetWidth' => null,
+                        'imageResizeTargetHeight' => null,
+                        'isLimitedToDirectory' => config('curator.features.directory_restriction', false),
+                        'isTenantAware' => config('curator.features.tenancy.enabled', false),
+                        'tenantOwnershipRelationshipName' => config('curator.features.tenancy.relationship_name'),
+                        'isMultiple' => false,
+                        'maxItems' => 1,
+                        'maxSize' => $component->getFileAttachmentsMaxSize() ?? 5000,
+                        'maxWidth' => null,
+                        'minSize' => 0,
+                        'pathGenerator' => config('curator.path_generator'),
+                        'rules' => [],
+                        'selected' => self::getSelectedMedia($arguments),
+                        'shouldPreserveFilenames' => false,
+                        'statePath' => $component->getStatePath(),
+                        'visibility' => config('curator.default_visibility', 'public'),
+                    ],
+                ]);
+            })
+            ->action(fn (): null => null);
+    }
+
+    protected static function getSelectedMedia(array $arguments): array
+    {
+        // If editing an existing image, try to find it in Curator by ID first
+        if (! empty($arguments['id']) && is_numeric($arguments['id'])) {
+            $media = Media::find($arguments['id']);
+            if ($media) {
+                return [$media->toArray()];
+            }
+        }
+
+        // Try to find by src URL
+        if (! empty($arguments['src'])) {
+            $filename = Str::of($arguments['src'])->afterLast('/')->beforeLast('.');
+            $media = Media::where('name', $filename)->first();
+            if ($media) {
+                return [$media->toArray()];
+            }
+        }
+
+        return [];
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'curatorMedia';
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds RichEditor integration for Filament v4, allowing users to insert Curator media directly into the RichEditor using a toolbar button.

### Implementation Approach

After researching Filament v4's RichEditor architecture, this implementation:

1. **Uses Filament's native `run-rich-editor-commands` event** - The same event system that Filament uses internally for RichEditor commands
2. **Combines Action and Tool in one class** - `CuratorMediaAction` provides both the toolbar button configuration and the modal action
3. **Captures cursor position in JavaScript** - Captures TipTap editor selection at button click time, eliminating the need to pass it through Livewire
4. **Minimal footprint** - Only adds 2 new files and modifies 1 existing file

### Files Added/Modified

- `src/RichEditor/CuratorMediaAction.php` (new) - Combined Action + Tool class
- `resources/js/richeditor-integration.js` (new) - JS bridge using native Filament events
- `src/CuratorServiceProvider.php` (modified) - Registers the JS asset

### Usage

```php
use Awcodes\Curator\RichEditor\CuratorMediaAction;

RichEditor::make('content')
    ->toolbarButtons([
        'bold', 'italic', 'curatorMedia', // ... other buttons
    ])
    ->tools([
        CuratorMediaAction::tool(),
    ])
    ->registerActions([
        CuratorMediaAction::make(),
    ])
    ->fileAttachments(false)  // Optional: disable default file attachments
```

### Features

- Toolbar button with photo icon
- Opens Curator media picker modal
- Inserts selected image into RichEditor at cursor position
- Auto-closes modal after insertion
- Supports editing existing images (pre-selects media when clicking on image)
- Stores `data-id` attribute for media tracking
- Follows Filament's native RichEditor conventions

### Testing

Tested locally with Filament v4 and Curator v4.0.0-alpha.3:
- Modal opens correctly
- Media library loads and displays
- Image insertion works at correct cursor position
- Modal closes after insertion
- `data-id` attribute correctly rendered on images