### PR TITLE
Fix: Use Curator facade to determine isResizable/isPreviewable

### DIFF
--- a/src/View/Components/Glider.php
+++ b/src/View/Components/Glider.php
@@ -108,8 +108,8 @@ class Glider extends Component
                 caption: $media->caption,
                 width: $media->width,
                 height: $media->height,
-                isResizable: $media->is_resizable,
-                isPreviewable: $media->is_previewable,
+                isResizable: Curator::isResizable($media->ext),
+                isPreviewable: Curator::isPreviewable($media->ext),
             );
         }
 


### PR DESCRIPTION
 isResizable: $media->is_resizable,
 isPreviewable: $media->is_previewable,

 These properties don't exist on the Media model, causing images to render as document placeholders.

  The fix I applied uses the same approach as handleMedia()