### PR TITLE
Fix: Handle missing files and unsupported temporaryUrl gracefully

### DIFF
--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -98,14 +98,20 @@ class Media extends Model
                 try {
                     $isPrivate = $storage->getVisibility($this->path) === 'private';
                 } catch (Throwable) {
-                    // ACL not supported on Storage Bucket, Laravel only throws exception here so need to be careful.
-                    // so we assume it's private
-                    $isPrivate = true;
+                    // Visibility check failed (file missing, ACL not supported, etc.)
+                    // Fall back to regular URL
+                    return $storage->url($this->path);
                 }
 
-                return $isPrivate
-                    ? $storage->temporaryUrl($this->path, now()->addMinutes(5))
-                    : $storage->url($this->path);
+                if ($isPrivate) {
+                    try {
+                        return $storage->temporaryUrl($this->path, now()->addMinutes(5));
+                    } catch (Throwable) {
+                        // Driver doesn't support temporary URLs, fall back to regular URL
+                    }
+                }
+
+                return $storage->url($this->path);
             },
         );
     }


### PR DESCRIPTION
The url() attribute would throw "This driver does not support creating temporary URLs" when:
1. A file doesn't exist (getVisibility throws, code assumed private)
2. The storage driver doesn't support temporaryUrl

Now falls back to regular URL in both cases. Missing file shouldn't break the whole page.