### PR TITLE
Fix: Use configured Media model instead of hardcoded class

### DIFF
--- a/src/Components/Modals/Concerns/InteractsWithStorage.php
+++ b/src/Components/Modals/Concerns/InteractsWithStorage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Awcodes\Curator\Components\Modals\Concerns;
 
 use Awcodes\Curator\Models\Media;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 
 trait InteractsWithStorage
@@ -15,7 +16,7 @@ trait InteractsWithStorage
 
     public function getDirectories(): void
     {
-        $directories = Media::query()->select('directory')
+        $directories = App::make(Media::class)::query()->select('directory')
             ->whereNotNull('directory')
             ->distinct()
             ->get()

--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -166,7 +166,7 @@ class CuratorPanel extends Component implements HasActions, HasSchemas
 
     public function getFiles(int $page = 0, bool $excludeSelected = false): array
     {
-        $files = Media::query()
+        $files = App::make(Media::class)::query()
             ->where('directory', $this->directory)
             ->when(filament()->hasTenancy() && $this->isTenantAware, fn ($query) => $query->where($this->tenantOwnershipRelationshipName.'_id', filament()->getTenant()->id))
 //            ->when($this->selected, function ($query, $selected) {
@@ -311,7 +311,7 @@ class CuratorPanel extends Component implements HasActions, HasSchemas
             ->modalWidth(Width::Medium)
             ->schema(App::make(MediaForm::class)::getAdditionalInformationFormSchema())
             ->fillForm(function (array $arguments): array {
-                $record = Media::query()->where('id', $arguments['item']['id'])->first() ?? null;
+                $record = App::make(Media::class)::query()->where('id', $arguments['item']['id'])->first() ?? null;
 
                 return $record ? $record->toArray() : [];
             })

--- a/src/Http/Controllers/MediaController.php
+++ b/src/Http/Controllers/MediaController.php
@@ -9,6 +9,7 @@ use Awcodes\Curator\Facades\Curator;
 use Awcodes\Curator\Models\Media;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Storage;
 use League\Glide\Filesystem\FileNotFoundException;
 use League\Glide\Filesystem\FilesystemException;
@@ -33,7 +34,7 @@ class MediaController extends Controller
             abort(403);
         }
 
-        $media = Media::query()
+        $media = App::make(Media::class)::query()
             ->where('path', $path)
             ->first();
 


### PR DESCRIPTION
Media::query() bypasses the service container binding and always uses the base Media class, ignoring the model configured in curator.php