### PR TITLE
Downgrade filament/filament dependency to ^4.0 in v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   ],
   "require": {
     "php": "^8.2",
-    "filament/filament": "^5.0",
+    "filament/filament": "^4.0",
     "league/glide": "^3.0",
     "spatie/laravel-package-tools": "^1.15.0"
   },


### PR DESCRIPTION
version 4 of the package should require `filament/filament:"^4.0"` not `filament\filament:"^5.0"`

more details in Issus #671 