### PR TITLE
Fix directory evaluation when no PathGenerator is used

### DIFF
--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -112,7 +112,7 @@ class Uploader extends FileUpload
         ) {
             $path = App::make($generator)->getPath($directory);
         } else {
-            $path = $this->evaluate($this->directory);
+            $path = $this->evaluate($directory);
         }
 
         return $this->normalizePath($path);


### PR DESCRIPTION
The fallback in getDirectory() evaluates $this->directory instead of the already resolved $directory.

This can ignore the config('curator.default_directory') fallback when the property is null and when no PathGenerator is used.