### PR TITLE
Fix uppercase file extensions not rendering thumbnails

### DIFF
--- a/src/Components/Forms/Uploader.php
+++ b/src/Components/Forms/Uploader.php
@@ -45,7 +45,7 @@ class Uploader extends FileUpload
                 ? Str::of(pathinfo($file->getClientOriginalName(), PATHINFO_FILENAME))->slug()
                 : (string) Str::uuid();
 
-            $extension = $file->getClientOriginalExtension();
+            $extension = mb_strtolower($file->getClientOriginalExtension());
 
             $storeMethod = $component->getVisibility() === 'public' ? 'storePubliclyAs' : 'storeAs';
 

--- a/src/Config/Concerns/HasRenderableType.php
+++ b/src/Config/Concerns/HasRenderableType.php
@@ -12,17 +12,19 @@ trait HasRenderableType
 {
     public function isResizable(string $extension): bool
     {
+        $extension = mb_strtolower($extension);
+
         return in_array($extension, PreviewableExtensions::toArray()) && $extension !== PreviewableExtensions::Svg->value;
     }
 
     public function isPreviewable(string $extension): bool
     {
-        return in_array($extension, PreviewableExtensions::toArray());
+        return in_array(mb_strtolower($extension), PreviewableExtensions::toArray());
     }
 
     public function isVideo(string $extension): bool
     {
-        return in_array($extension, VideoExtensions::toArray());
+        return in_array(mb_strtolower($extension), VideoExtensions::toArray());
     }
 
     public function isDocument(string $extension): bool
@@ -32,11 +34,11 @@ trait HasRenderableType
 
     public function isSvg(string $extension): bool
     {
-        return $extension === PreviewableExtensions::Svg->value;
+        return mb_strtolower($extension) === PreviewableExtensions::Svg->value;
     }
 
     public function isAudio(string $extension): bool
     {
-        return in_array($extension, AudioExtensions::toArray());
+        return in_array(mb_strtolower($extension), AudioExtensions::toArray());
     }
 }

--- a/src/CuratorUtils.php
+++ b/src/CuratorUtils.php
@@ -40,7 +40,7 @@ class CuratorUtils
             $fileContents = file_get_contents($path);
         }
 
-        $ext = (string) Str::of($path)->afterLast('.');
+        $ext = (string) Str::of($path)->afterLast('.')->lower();
 
         $filename = Curator::shouldPreserveFilenames()
             ? (string) Str::of(pathinfo($path, PATHINFO_FILENAME))->slug()

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -40,7 +40,7 @@ if (! function_exists('glide_builder')) {
 if (! function_exists('is_media_resizable')) {
     function is_media_resizable(string $ext): bool
     {
-        return in_array($ext, ['jpeg', 'jpg', 'png', 'webp', 'bmp']);
+        return in_array(mb_strtolower($ext), ['jpeg', 'jpg', 'png', 'webp', 'bmp']);
     }
 }
 

--- a/tests/src/Unit/Config/CuratorManagerTest.php
+++ b/tests/src/Unit/Config/CuratorManagerTest.php
@@ -102,3 +102,18 @@ test('shouldPreserveFilenames returns true when set', function () {
 
     expect($manager->shouldPreserveFilenames())->toBeTrue();
 });
+
+test('renderable type checks are case-insensitive', function (string $extension) {
+    $manager = new CuratorManager();
+
+    expect($manager->isResizable($extension))->toBeTrue()
+        ->and($manager->isPreviewable($extension))->toBeTrue()
+        ->and($manager->isDocument($extension))->toBeFalse();
+})->with(['JPG', 'JPEG', 'PNG', 'WebP', 'Bmp']);
+
+test('isSvg and isAudio are case-insensitive', function () {
+    $manager = new CuratorManager();
+
+    expect($manager->isSvg('SVG'))->toBeTrue()
+        ->and($manager->isAudio('MP3'))->toBeTrue();
+});

--- a/tests/src/Unit/CuratorUtilsTest.php
+++ b/tests/src/Unit/CuratorUtilsTest.php
@@ -25,6 +25,27 @@ test('local image file import returns expected array keys', function () {
     ]);
 });
 
+test('normalizes uppercase extensions to lowercase', function () {
+    Storage::fake('public');
+
+    $tmpPath = sys_get_temp_dir().'/curator-test-image.JPG';
+    $image = imagecreatetruecolor(100, 100);
+    imagejpeg($image, $tmpPath);
+    imagedestroy($image);
+
+    $result = CuratorUtils::importMedia(
+        path: $tmpPath,
+        disk: 'public',
+        directory: 'test',
+        visibility: 'public',
+    );
+
+    expect($result['ext'])->toBe('jpg')
+        ->and($result['path'])->toEndWith('.jpg');
+
+    @unlink($tmpPath);
+});
+
 test('sets width and height for resizable images', function () {
     Storage::fake('public');
 


### PR DESCRIPTION
Fixes #709

## Problem

Files uploaded with an uppercase extension (e.g. `photo.JPG`) didn't render thumbnails in the media browser.

## Root cause

The type-detection helpers — `isResizable`, `isPreviewable`, `isVideo`, `isSvg`, `isAudio` (in `HasRenderableType`) and the `is_media_resizable` helper — compared the stored extension against lowercase enum values using a case-sensitive `in_array`. A stored `JPG` matched nothing, so the file was treated as a non-image document and no thumbnail was generated.

## Fix

Two layers:

1. **Comparison** — lowercase the extension in every type check. This fixes display for media **already in the database** with uppercase extensions, no migration required.
2. **Write** — normalize the extension to lowercase on upload (`Uploader`) and import (`CuratorUtils`) so new records are stored consistently (`ext` and `path`).

## Tests

- `CuratorManagerTest`: type checks are case-insensitive (`JPG`, `JPEG`, `PNG`, `WebP`, `Bmp`, `SVG`, `MP3`).
- `CuratorUtilsTest`: uppercase extension is stored lowercase in both `ext` and `path`.

Full unit suite passes (138 tests).

> Note: targeting `4.x`. `5.x` is functionally identical (only the Filament version differs) and will pick this up when `4.x` is merged into `5.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)