### PR TITLE
Test against Laravel 12 and 13 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,16 +22,20 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        php: [8.5, 8.4, 8.3]
+        laravel: [13.*, 12.*]
         stability: [prefer-stable]
+        exclude:
+          # Laravel 13 requires PHP 8.4+
+          - laravel: 13.*
+            php: 8.3
         include:
-          - laravel: 12.*
-            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
             carbon: 3.*
             collision: 8.*
-          - laravel: 11.*
-            testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
             carbon: 3.*
             collision: 8.*
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require-dev": {
     "laravel/pint": "^1.10",
-    "orchestra/testbench": "^9.0|^10.0",
+    "orchestra/testbench": "^9.0|^10.0|^11.0",
     "pestphp/pest": "^3.0",
     "pestphp/pest-plugin-laravel": "^3.0",
     "pestphp/pest-plugin-livewire": "^3.0",


### PR DESCRIPTION
## What

Update the test workflow matrix to drop Laravel 11 and add Laravel 13.

- **PHP:** `8.3`, `8.4`, `8.5`
- **Laravel:** `12.*`, `13.*` (Laravel 11 removed)
- Laravel 13 requires PHP 8.4+, so the `13.* + 8.3` combination is excluded.
- Laravel 13 runs use `orchestra/testbench:11.*`; Laravel 12 stays on `10.*`.

Resulting combinations:

| Laravel | PHP 8.3 | PHP 8.4 | PHP 8.5 |
|---|---|---|---|
| 13.* | — | ✓ | ✓ |
| 12.* | ✓ | ✓ | ✓ |

## composer.json

Widened `orchestra/testbench` to `^9.0|^10.0|^11.0`. The package still supports Laravel 11 (testbench 9) — it's just no longer exercised in CI — while testbench 11 enables the Laravel 13 runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)