### PR TITLE
Gate bulk upload behind the create policy

### DIFF
--- a/src/Actions/MultiUploadAction.php
+++ b/src/Actions/MultiUploadAction.php
@@ -24,16 +24,19 @@ class MultiUploadAction extends Action
             ->button()
             ->color('gray')
             ->authorize(function (): bool {
-                $policy = Gate::getPolicyFor(MediaResource::getModel());
+                // Resolve the resource from the container so any config override
+                // (curator.resource.resource / curator.model) is respected.
+                $resource = App::make(MediaResource::class);
+                $policy = Gate::getPolicyFor($resource::getModel());
 
                 // Restrict bulk upload with a dedicated `bulkUpload` policy ability
                 // when one is provided, otherwise fall back to the standard `create`
                 // ability so it matches the resource's create authorization.
                 if ($policy !== null && method_exists($policy, 'bulkUpload')) {
-                    return MediaResource::can('bulkUpload');
+                    return $resource::can('bulkUpload');
                 }
 
-                return MediaResource::canCreate();
+                return $resource::canCreate();
             })
             ->label(trans('curator::forms.multi_upload.action_label'))
             ->modalHeading(trans('curator::forms.multi_upload.modal_heading'))

--- a/src/Actions/MultiUploadAction.php
+++ b/src/Actions/MultiUploadAction.php
@@ -7,9 +7,11 @@ namespace Awcodes\Curator\Actions;
 use Awcodes\Curator\Components\Forms\Uploader;
 use Awcodes\Curator\Facades\Curator;
 use Awcodes\Curator\Models\Media;
+use Awcodes\Curator\Resources\Media\MediaResource;
 use Exception;
 use Filament\Actions\Action;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Gate;
 
 class MultiUploadAction extends Action
 {
@@ -21,6 +23,18 @@ class MultiUploadAction extends Action
         $this
             ->button()
             ->color('gray')
+            ->authorize(function (): bool {
+                $policy = Gate::getPolicyFor(MediaResource::getModel());
+
+                // Restrict bulk upload with a dedicated `bulkUpload` policy ability
+                // when one is provided, otherwise fall back to the standard `create`
+                // ability so it matches the resource's create authorization.
+                if ($policy !== null && method_exists($policy, 'bulkUpload')) {
+                    return MediaResource::can('bulkUpload');
+                }
+
+                return MediaResource::canCreate();
+            })
             ->label(trans('curator::forms.multi_upload.action_label'))
             ->modalHeading(trans('curator::forms.multi_upload.modal_heading'))
             ->schema([

--- a/tests/src/Feature/Actions/MultiUploadActionTest.php
+++ b/tests/src/Feature/Actions/MultiUploadActionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Awcodes\Curator\Models\Media;
+use Awcodes\Curator\Resources\Media\Pages\ListMedia;
+use Awcodes\Curator\Tests\Fixtures\Policies\MediaBulkUploadPolicy;
+use Awcodes\Curator\Tests\Fixtures\Policies\MediaCreateAllowedPolicy;
+use Awcodes\Curator\Tests\Fixtures\Policies\MediaCreateDeniedPolicy;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+
+$action = 'curator_multi_upload';
+
+test('bulk upload is visible when no media policy is registered', function () use ($action) {
+    Livewire::test(ListMedia::class)
+        ->assertActionVisible($action);
+});
+
+test('bulk upload falls back to the create ability when allowed', function () use ($action) {
+    Gate::policy(Media::class, MediaCreateAllowedPolicy::class);
+
+    Livewire::test(ListMedia::class)
+        ->assertActionVisible($action);
+});
+
+test('bulk upload is hidden when the create ability is denied', function () use ($action) {
+    Gate::policy(Media::class, MediaCreateDeniedPolicy::class);
+
+    Livewire::test(ListMedia::class)
+        ->assertActionHidden($action);
+});
+
+test('bulk upload uses the bulkUpload ability when the policy provides it', function () use ($action) {
+    // create() is allowed on this policy, so the action being hidden proves the
+    // dedicated bulkUpload() ability takes precedence over create().
+    Gate::policy(Media::class, MediaBulkUploadPolicy::class);
+
+    Livewire::test(ListMedia::class)
+        ->assertActionHidden($action);
+});

--- a/tests/src/Fixtures/Policies/MediaBulkUploadPolicy.php
+++ b/tests/src/Fixtures/Policies/MediaBulkUploadPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Awcodes\Curator\Tests\Fixtures\Policies;
+
+use Awcodes\Curator\Tests\Fixtures\Models\User;
+
+class MediaBulkUploadPolicy
+{
+    public function create(User $user): bool
+    {
+        // create is allowed, so a passing bulkUpload check must be what gates
+        // the action — proving the dedicated ability takes precedence.
+        return true;
+    }
+
+    public function bulkUpload(User $user): bool
+    {
+        return false;
+    }
+}

--- a/tests/src/Fixtures/Policies/MediaCreateAllowedPolicy.php
+++ b/tests/src/Fixtures/Policies/MediaCreateAllowedPolicy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Awcodes\Curator\Tests\Fixtures\Policies;
+
+use Awcodes\Curator\Tests\Fixtures\Models\User;
+
+class MediaCreateAllowedPolicy
+{
+    public function create(User $user): bool
+    {
+        return true;
+    }
+}

--- a/tests/src/Fixtures/Policies/MediaCreateDeniedPolicy.php
+++ b/tests/src/Fixtures/Policies/MediaCreateDeniedPolicy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Awcodes\Curator\Tests\Fixtures\Policies;
+
+use Awcodes\Curator\Tests\Fixtures\Models\User;
+
+class MediaCreateDeniedPolicy
+{
+    public function create(User $user): bool
+    {
+        return false;
+    }
+}


### PR DESCRIPTION
Fixes #710

## Problem

The `MultiUploadAction` (bulk upload) on the media grid was registered with no authorization check, while `CreateAction` automatically enforces the resource's `create` policy. Filament v4 actions have **no** automatic policy-based authorization (see the security note in `CanBeAuthorized`), so any panel user could bulk upload media regardless of their permissions elsewhere in the panel.

## Fix

Added a default `authorize()` to `MultiUploadAction` that mirrors the reporter's suggestion:

- If the media policy defines a dedicated **`bulkUpload`** ability, use it.
- Otherwise fall back to the standard **`create`** ability, matching the resource's create authorization.

Authorization is delegated to `MediaResource` (`canCreate()` / `can('bulkUpload')`) rather than a raw `Gate::allows`, so the standard Filament semantics are preserved:

- **No policy registered → allowed** (no regression for apps without a media policy).
- Respects `skipAuthorization()` and the configured media model.

Users can still override per-instance with `MultiUploadAction::make()->authorize(...)`.

## Tests

`tests/src/Feature/Actions/MultiUploadActionTest.php` covers:
- No policy → action visible
- `create` allowed → visible
- `create` denied → hidden
- `bulkUpload` denied while `create` allowed → hidden (dedicated ability takes precedence)

Full unit suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)