### PR TITLE
Fix tenant leak in CuratorPanel search (3.x backport)

### DIFF
--- a/src/Components/Modals/CuratorPanel.php
+++ b/src/Components/Modals/CuratorPanel.php
@@ -307,14 +307,19 @@ class CuratorPanel extends Component implements HasActions, HasForms
     {
         $this->files = $this->mediaClass
             ->query()
+            ->when(filament()->hasTenancy() && $this->isTenantAware, function ($query) {
+                return $query->where($this->tenantOwnershipRelationshipName . '_id', filament()->getTenant()->id);
+            })
             ->when($this->isLimitedToDirectory, function ($query) {
                 return $query->where('directory', $this->directory);
             })
-            ->where('name', 'like', '%' . $this->search . '%')
-            ->orWhere('title', 'like', '%' . $this->search . '%')
-            ->orWhere('alt', 'like', '%' . $this->search . '%')
-            ->orWhere('caption', 'like', '%' . $this->search . '%')
-            ->orWhere('description', 'like', '%' . $this->search . '%')
+            ->where(function ($query) {
+                $query->where('name', 'like', '%' . $this->search . '%')
+                    ->orWhere('title', 'like', '%' . $this->search . '%')
+                    ->orWhere('alt', 'like', '%' . $this->search . '%')
+                    ->orWhere('caption', 'like', '%' . $this->search . '%')
+                    ->orWhere('description', 'like', '%' . $this->search . '%');
+            })
             ->limit(50)
             ->get()
             ->toArray();


### PR DESCRIPTION
Backport of the tenant search leak fix already shipped in 4.1.1 and 5.1.1.

## Problem

`CuratorPanel::updatedSearch()` built its query without the tenant ownership scope that `getFiles()` applies, so in multitenant panels an authenticated user could retrieve media metadata belonging to other tenants via the picker search (CWE-284). The ungrouped `orWhere` chain also broke out of the `isLimitedToDirectory` filter.

The vulnerability dates back to v3.2.4 (when multitenancy support was added to the picker).

## Fix

Apply the same tenant scope used by `getFiles()` and wrap the search terms in a nested group so they can't escape the directory/tenant constraints. Identical in behavior to the merged 4.x/5.x fix.

## Note on tests

The 3.x branch has no Livewire/feature test infrastructure or tenancy fixtures (unlike 4.x/5.x), so this carries no new automated test. The change is syntax-checked and mirrors the regression-tested fix on the newer branches. Happy to build out the test harness if we want coverage here.

Security release to follow.