### PR TITLE
fix: align Media docblock with the nullable migration columns

### DIFF
--- a/resources/views/components/forms/details.blade.php
+++ b/resources/views/components/forms/details.blade.php
@@ -31,7 +31,7 @@
                 {{ trans('curator::views.details.file_size') }}
             </dt>
             <dd class="{{ $dataClasses }}">
-                {{ filled($record) ? curator()->sizeForHumans($record->size) : '-' }}
+                {{ filled($record?->size) ? curator()->sizeForHumans($record->size) : '-' }}
             </dd>
         </div>
         <div>

--- a/resources/views/components/forms/picker.blade.php
+++ b/resources/views/components/forms/picker.blade.php
@@ -40,7 +40,7 @@
                                 <p>{{ $item['pretty_name'] }}</p>
                             </div>
                             <div class="curator-picker-list-details flex-shrink-0 ml-auto py-2">
-                                <p>{{ curator()->sizeForHumans($item['size']) }}</p>
+                                <p>{{ filled($item['size']) ? curator()->sizeForHumans($item['size']) : null }}</p>
                             </div>
                             <div class="curator-picker-list-actions flex-shrink-0">
                                 <div class="relative flex items-center">

--- a/src/Models/Media.php
+++ b/src/Models/Media.php
@@ -20,13 +20,13 @@ use Throwable;
 /**
  * @property-read int|string $id
  * @property string $disk
- * @property string $directory
+ * @property string|null $directory
  * @property string $visibility
  * @property string $name
  * @property string $path
- * @property int $width
- * @property int $height
- * @property int $size
+ * @property int|null $width
+ * @property int|null $height
+ * @property int|null $size
  * @property string $type
  * @property string $ext
  * @property string|null $alt
@@ -38,7 +38,7 @@ use Throwable;
  * @property-read string $placeholder
  * @property-read CarbonInterface $created_at
  * @property-read CarbonInterface $updated_at
- * @property-read string $url
+ * @property-read string|null $url
  * @property-read string $full_path
  * @property-read string $thumbnail_url
  * @property-read string $medium_url

--- a/tests/src/Feature/NullableMediaColumnsTest.php
+++ b/tests/src/Feature/NullableMediaColumnsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Awcodes\Curator\Resources\Media\Pages\EditMedia;
+use Awcodes\Curator\Tests\Fixtures\Models\Mediable;
+use Awcodes\Curator\Tests\Fixtures\Models\Post;
+use Awcodes\Curator\Tests\Fixtures\Resources\Posts\Pages\EditPost;
+use Livewire\Livewire;
+
+// `size`, `width` and `height` are nullable in stubs/migration.stub, so any view
+// that displays them has to tolerate null rather than handing it straight to
+// sizeForHumans(int $size). See https://github.com/awcodes/filament-curator/issues/721.
+
+test('the media edit page renders a record with a null size', function () {
+    $media = makeMedia(['name' => 'no-size', 'size' => null, 'width' => null, 'height' => null]);
+
+    Livewire::test(EditMedia::class, ['record' => $media->id])
+        ->assertOk();
+});
+
+test('the picker list display renders an item with a null size', function () {
+    config()->set('curator_testing.picker_list_display', true);
+
+    $post = Post::create(['title' => 'Null size post']);
+    $media = makeMedia(['name' => 'no-size', 'size' => null, 'width' => null, 'height' => null]);
+
+    Mediable::create([
+        'mediable_type' => Post::class,
+        'mediable_id' => $post->id,
+        'media_id' => $media->id,
+        'order' => 1,
+    ]);
+
+    Livewire::test(EditPost::class, ['record' => $post->id])
+        ->assertOk();
+});

--- a/tests/src/Fixtures/Resources/Posts/PostResource.php
+++ b/tests/src/Fixtures/Resources/Posts/PostResource.php
@@ -30,6 +30,9 @@ class PostResource extends Resource
             CuratorPicker::make('gallery')
                 ->relationship('gallery', 'name')
                 ->multiple()
+                // Opt-in so a test can exercise the list markup without changing
+                // the default grid display the other tests render.
+                ->listDisplay(fn (): bool => (bool) config('curator_testing.picker_list_display', false))
                 ->orderColumn('order'),
         ]);
     }


### PR DESCRIPTION
Fixes #721.

## The reported bug

`Media`'s docblock declared four properties non-nullable that `stubs/migration.stub` creates as `nullable()`:

| property | stub |
|---|---|
| `directory` | `$table->string('directory')->nullable()` |
| `width` | `$table->unsignedInteger('width')->nullable()` |
| `height` | `$table->unsignedInteger('height')->nullable()` |
| `size` | `$table->unsignedInteger('size')->nullable()` |

Larastan believes the annotation, so correct null-handling in a consuming app gets reported as a defect — the reporter's `expect($media->width)->toBeNull()` for a sanitized SVG came back as `pest.expectation.impossible`.

All four now carry `|null`. I also corrected `@property-read string $url` → `string|null`, since it resolves through `Media::resolveUrl()`, which is already declared `?string`.

Per the issue's suggestion I checked the rest of the block against the stub. Everything else lines up: `alt`, `title`, `description`, `caption`, `exif` and `curations` already have `|null`; `disk`, `name`, `path`, `type` and `ext` are non-nullable columns and `visibility` has a `default('public')`; `pretty_name` is a nullable column but is in `$appends` with an accessor that always returns a string; the tenancy FK has a templated name, so there's nothing to annotate.

## Two real crashes the annotation was hiding

Chasing the `size` call sites turned up two views that hand a null straight into `sizeForHumans(int $size)` and fatal:

- `resources/views/components/forms/details.blade.php` — the details panel on the media **edit page**. The existing `filled($record)` guard checks the record, not the size.
- `resources/views/components/forms/picker.blade.php` — the **picker's list display**.

Both are guarded now, with a regression test per site in `tests/src/Feature/NullableMediaColumnsTest.php`. Both tests fail on `5.x` with `Argument #1 ($size) must be of type int, null given` and pass here.

The picker test needs the list markup, so `PostResource` gains an opt-in `listDisplay()` driven by a config flag — the other tests that render that fixture keep the default grid display.

## Checked and deliberately left alone

- **`MediaTable`'s size column** looks like the same bug but isn't reachable: `TextColumn` short-circuits to the placeholder branch on blank state and never calls `formatStateUsing`. Verified by running a null-size record through the list page unpatched.
- **`info-overlay.blade.php`** is also safe, for a different reason: Blade's `@props` default (`'size' => 0`) replaces an explicitly passed null, so it renders `0 B` rather than throwing. Cosmetically wrong for an unknown size, but not a crash, and changing it would alter the grid's rendering — happy to do it separately if you want.

## Notes

- `3.x` has a wider version of the same problem: its docblock also declares `alt`, `title`, `description`, `caption`, `exif` and `curations` non-nullable. Separate backport if you want it.
- `composer test` is green: 201 passed, PHPStan clean, no Pint or Rector drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)