### PR TITLE
fix: resolve string media keys in the glider component

### DIFF
--- a/resources/views/components/display/document.blade.php
+++ b/resources/views/components/display/document.blade.php
@@ -1,7 +1,7 @@
 @props([
     'label' => null,
     'iconSize' => 'md',
-    'extension' => 'pdf',
+    'extension' => null,
 ])
 
 @php

--- a/resources/views/components/glider.blade.php
+++ b/resources/views/components/glider.blade.php
@@ -14,6 +14,7 @@
     @else
         <x-curator::display.document
             label="{{ $mediaItem->getName() }}"
+            :extension="$mediaItem->getExtension()"
             icon-size="xl"
             {{ $attributes->merge(['class' => 'p-4']) }}
         />

--- a/src/Config/GlideManager.php
+++ b/src/Config/GlideManager.php
@@ -6,6 +6,7 @@ namespace Awcodes\Curator\Config;
 
 use Awcodes\Curator\Config\Concerns\HasGliderFallbacks;
 use Awcodes\Curator\Glide\SymfonyResponseFactory;
+use Exception;
 use Filament\Support\Concerns\EvaluatesClosures;
 use Illuminate\Support\Str;
 use League\Glide\Server;
@@ -52,9 +53,21 @@ class GlideManager
         return $this->basePath ?? 'curator';
     }
 
+    /**
+     * @throws Exception
+     */
     public function getToken(): string
     {
-        return config('curator.glide_token');
+        $token = config('curator.glide_token');
+
+        // curator:install writes this into the .env of the machine it ran on, so
+        // a second checkout or a fresh deploy target reliably arrives without
+        // one. Say which knob is missing rather than raising a return type error.
+        if (blank($token)) {
+            throw new Exception(message: 'Curator has no Glide token. Run `php artisan curator:token` to generate one, or set CURATOR_GLIDE_TOKEN in this environment.');
+        }
+
+        return $token;
     }
 
     public function getUrl(string $path, ?array $params = []): string

--- a/src/DTO/MediaDTO.php
+++ b/src/DTO/MediaDTO.php
@@ -17,6 +17,7 @@ class MediaDTO
         public ?int $height = null,
         public ?bool $isResizable = null,
         public ?bool $isPreviewable = null,
+        public ?string $ext = null,
     ) {}
 
     public function getName(): ?string
@@ -57,6 +58,11 @@ class MediaDTO
     public function getPath(): string
     {
         return $this->path;
+    }
+
+    public function getExtension(): ?string
+    {
+        return $this->ext;
     }
 
     public function isResizable(): bool

--- a/src/View/Components/Glider.php
+++ b/src/View/Components/Glider.php
@@ -58,16 +58,12 @@ class Glider extends Component
         public ?string $watermarkPosition = null,
         public ?string $watermarkAlpha = null,
     ) {
-        if (is_string($media) && filled($media)) {
-            $this->handleString($media);
-        }
-
-        if (is_int($media)) {
-            $this->handleInt($media);
-        }
-
         if (is_a($media, Media::class)) {
             $this->handleMedia($media);
+        } elseif (is_int($media) || (is_string($media) && static::isMediaKey($media))) {
+            $this->handleId($media);
+        } elseif (is_string($media) && filled($media)) {
+            $this->handleString($media);
         }
 
         // A null media item, or an id that no longer resolves, is the case the
@@ -81,6 +77,18 @@ class Glider extends Component
         }
     }
 
+    /**
+     * A media id reaches the component as a string whenever it comes back out of
+     * a json column, a query string or a settings array, so a bare key has to be
+     * looked up rather than taken for a path. Curator's own primary keys are
+     * either auto-incrementing integers or uuids (see stubs/migration.stub), and
+     * a path always carries an extension, so neither shape is ambiguous.
+     */
+    public static function isMediaKey(string $media): bool
+    {
+        return ctype_digit($media) || Str::isUuid($media) || Str::isUlid($media);
+    }
+
     public function handleString(string $media): void
     {
         $extension = (string) Str::of($media)->afterLast('.');
@@ -89,12 +97,13 @@ class Glider extends Component
             path: $media,
             isResizable: Curator::isResizable($extension),
             isPreviewable: Curator::isPreviewable($extension),
+            ext: $extension,
         );
     }
 
-    public function handleInt(int $media): void
+    public function handleId(int | string $media): void
     {
-        $record = app(Media::class)->where('id', $media)->first();
+        $record = app(Media::class)->whereKey($media)->first();
 
         // Leave mediaItem unset so the constructor can reach for the fallback.
         if (! $record instanceof Media) {
@@ -102,6 +111,12 @@ class Glider extends Component
         }
 
         $this->handleMedia($record);
+    }
+
+    /** @deprecated Use handleId(), which also accepts string keys. */
+    public function handleInt(int $media): void
+    {
+        $this->handleId($media);
     }
 
     public function handleFallback(): void
@@ -130,6 +145,7 @@ class Glider extends Component
             height: $fallback->getHeight(),
             isResizable: $fallback->isResizable(),
             isPreviewable: $fallback->isPreviewable(),
+            ext: $fallback->getType() ?? (string) Str::of($fallback->getSource())->afterLast('.'),
         );
     }
 
@@ -145,6 +161,7 @@ class Glider extends Component
             height: $media->height,
             isResizable: Curator::isResizable($media->ext),
             isPreviewable: Curator::isPreviewable($media->ext),
+            ext: $media->ext,
         );
 
         $this->mediaItem = $dto;

--- a/tests/src/Feature/Components/GliderMediaKeyTest.php
+++ b/tests/src/Feature/Components/GliderMediaKeyTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use Awcodes\Curator\Facades\Glide;
+use Awcodes\Curator\Glide\GliderFallback;
+use Awcodes\Curator\View\Components\Glider;
+use Illuminate\Support\Facades\Blade;
+
+// A media id arrives as a string whenever it comes back out of a json column, a
+// settings array or a query string. It used to be taken for a path, which left
+// the component rendering the document placeholder for a perfectly good image.
+// See https://github.com/awcodes/filament-curator/issues/719.
+
+test('a numeric string id resolves the record rather than being read as a path', function () {
+    $media = makeMedia(['path' => 'real.jpg', 'ext' => 'jpg']);
+
+    $glider = new Glider(media: (string) $media->id);
+
+    expect($glider->mediaItem->getPath())->toBe('real.jpg')
+        ->and($glider->mediaItem->isPreviewable())->toBeTrue();
+});
+
+test('a path is still treated as a path', function () {
+    $glider = new Glider(media: 'images/banner.jpg');
+
+    expect($glider->mediaItem->getPath())->toBe('images/banner.jpg')
+        ->and($glider->mediaItem->isPreviewable())->toBeTrue();
+});
+
+test('a string id that does not resolve reaches the fallback', function () {
+    Glide::registerGliderFallbacks([
+        GliderFallback::make('thumbnail')->source('fallback.jpg')->type('jpg'),
+    ]);
+
+    $glider = new Glider(media: '999', fallback: 'thumbnail');
+
+    expect($glider->mediaItem->getPath())->toBe('fallback.jpg');
+});
+
+// The install command offers uuid primary keys, so a key is not always numeric.
+test('isMediaKey recognises the key shapes curator issues', function (string $value) {
+    expect(Glider::isMediaKey($value))->toBeTrue();
+})->with([
+    '10',
+    '9223372036854775807',
+    '3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+    '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+]);
+
+test('isMediaKey leaves anything path shaped alone', function (string $value) {
+    expect(Glider::isMediaKey($value))->toBeFalse();
+})->with([
+    'images/banner.jpg',
+    'banner.jpg',
+    '10.jpg',
+    'media/2024/10',
+    '',
+]);
+
+// The document placeholder defaulted its label to "pdf" and the glider never
+// passed the real one, so every non-previewable file rendered as a PDF.
+test('a record media item carries its extension to the placeholder', function () {
+    $media = makeMedia(['path' => 'notes.docx', 'ext' => 'docx', 'type' => 'application/msword']);
+
+    $glider = new Glider(media: $media->id);
+
+    expect($glider->mediaItem->isPreviewable())->toBeFalse()
+        ->and($glider->mediaItem->getExtension())->toBe('docx');
+});
+
+test('a path media item carries its extension too', function () {
+    $glider = new Glider(media: 'archive/report.docx');
+
+    expect($glider->mediaItem->getExtension())->toBe('docx');
+});
+
+test('the rendered placeholder labels the real extension instead of pdf', function () {
+    $media = makeMedia(['path' => 'notes.docx', 'ext' => 'docx', 'type' => 'application/msword']);
+
+    $html = Blade::render('<x-curator-glider :media="$media" />', ['media' => $media->id]);
+
+    expect($html)->toContain('>docx<')
+        ->and($html)->not->toContain('>pdf<');
+});
+
+test('a fallback media item carries its extension too', function () {
+    Glide::registerGliderFallbacks([
+        GliderFallback::make('doc')->source('placeholder.docx'),
+    ]);
+
+    $glider = new Glider(media: null, fallback: 'doc');
+
+    expect($glider->mediaItem->getExtension())->toBe('docx');
+});

--- a/tests/src/Unit/Config/GlideManagerTest.php
+++ b/tests/src/Unit/Config/GlideManagerTest.php
@@ -31,6 +31,14 @@ test('getToken returns value from config', function () {
     expect($manager->getToken())->toBe(config('curator.glide_token'));
 });
 
+// A checkout that never ran curator:install has no token, and the return type
+// error that used to surface said nothing about how to fix it.
+test('getToken names the missing token instead of raising a type error', function () {
+    config()->set('curator.glide_token', null);
+
+    (new GlideManager())->getToken();
+})->throws(Exception::class, 'Curator has no Glide token.');
+
 test('getUrl returns a string URL containing the path', function () {
     $manager = new GlideManager();
 


### PR DESCRIPTION
Fixes #719.

## 1. The reported bug: `:media="$image"` renders a placeholder, `:media="(int) $image"` renders the image

The reporter had it right in [their third comment](https://github.com/awcodes/filament-curator/issues/719#issuecomment-list). `Glider::__construct()` only matched `is_int()`, so a string key fell through to `handleString()`, which reads the value as a path:

```php
$extension = (string) Str::of('10')->afterLast('.'); // "10"
```

`isPreviewable("10")` is false, so the component rendered the document placeholder for a perfectly good image. Their data is `['banners' => ["10", "7"]]` in a json settings column — no relationship or model override involved, which is what wasn't adding up in the thread. Any id that round-trips through json, a query string or a settings array arrives as a string.

A bare key is now looked up instead of being taken for a path:

```php
if (is_a($media, Media::class)) {
    $this->handleMedia($media);
} elseif (is_int($media) || (is_string($media) && static::isMediaKey($media))) {
    $this->handleId($media);
} elseif (is_string($media) && filled($media)) {
    $this->handleString($media);
}
```

`isMediaKey()` matches the key shapes curator issues — digits, plus uuids and ulids, since `curator:install --use-uuid` writes `$table->uuid('id')->primary()`. A path always carries an extension, so the two shapes don't overlap; `'10.jpg'`, `'banner.jpg'` and `'media/2024/10'` all still take the path branch, and there are tests pinning that.

`handleInt()` is kept as a deprecated delegate to the widened `handleId()`, so anything extending the component keeps working. A string key that doesn't resolve reaches the fallback, same as an int that doesn't.

## 2. The placeholder labels everything "PDF"

Worth fixing while in here, and it's half of what the reporter was looking at. `resources/views/components/display/document.blade.php` declares `'extension' => 'pdf'` as its prop default, and `glider.blade.php` never passed one — so *every* non-previewable file the glider rendered came out labelled PDF, and the video branch in that component was unreachable. (`display/index.blade.php` was already doing this correctly with `$item->ext`.)

`MediaDTO` now carries `ext`, populated from all three sources — record, path, and fallback (via its `type()`, falling back to the source's extension) — and the hardcoded default is gone. A `.docx` now renders labelled `docx`.

## 3. The Glide token error

Docs for this landed in dafd5c2 already, so this is only the error itself. `GlideManager::getToken(): string` returned `config('curator.glide_token')` straight, so a checkout that never ran `curator:install` got:

```
Awcodes\Curator\Config\GlideManager::getToken(): Return value must be of type string, null returned
```

It now names the missing variable and the command that generates it. This is exactly the reporter's "1 pc has it, the other doesn't" situation.

## Tests

`tests/src/Feature/Components/GliderMediaKeyTest.php` — 16 cases covering key resolution, the path branch staying put, fallback on an unresolvable string key, extension propagation from each source, and a rendered-html assertion that the placeholder says `docx` and not `pdf`. All but the "a path is still treated as a path" no-regression guard fail on `5.x`.

`composer test` is green: 218 passed, PHPStan clean, no Pint or Rector drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)