### PR TITLE
chore: stop Dependabot offering league/glide majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,20 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 14
+    # league/glide majors are excluded on purpose. Glide 4 is not a bump: it requires
+    # PHP ^8.3 (this package declares ^8.2) and moves intervention/image from v3 to v4.
+    # This package calls the Intervention API directly through
+    # `Glide::getServer()->getApi()->getImageManager()` without requiring
+    # intervention/image itself, so Glide's choice of major silently governs that
+    # surface — `read()`, `toJpeg()`, `encodeByExtension()` and `flop()` all move or
+    # disappear in v4, and v3's `flip()` (vertical) becomes v4's `flip()` (horizontal by
+    # default), which changes behaviour without erroring. Adopting it means raising the
+    # PHP floor, declaring intervention/image directly and migrating the image pipeline
+    # — a deliberate major, not a Dependabot PR. Minor and patch updates within 3.x
+    # still come through. See #725.
+    ignore:
+      - dependency-name: "league/glide"
+        update-types: ["version-update:semver-major"]
     groups:
       dev-dependencies:
         dependency-type: development


### PR DESCRIPTION
Closes the loop on #725, which is being closed unmerged.

Glide 4 is a migration, not a bump:

- it requires PHP `^8.3` while this package declares `^8.2`, and
- it moves `intervention/image` from v3 to v4.

The second part is the expensive one. This package calls the Intervention API directly through `Glide::getServer()->getApi()->getImageManager()` but never requires `intervention/image` itself, so Glide's choice of major quietly governs an API surface used across four files — `CuratorUtils`, `Models\Media`, `Forms\Uploader` and `Modals\CuratorCuration`.

In Intervention v4, `ImageManager::read()`, `toJpeg()`, `encodeByExtension()` and `flop()` are renamed or gone. Glide's own surface is unaffected — every Glide class this package imports still exists at 4.1.0 — so the whole break arrives transitively.

The one worth calling out: v3's `flip()` is vertical and `flop()` is horizontal, but v4 exposes only `flip(Direction $direction = Direction::HORIZONTAL)`. `flop()` fatals loudly, while `flip()` keeps compiling and silently flips the wrong axis in the curation pipeline. Static Analysis passed on #725 while all 7 test jobs failed, so PHPStan is not a safety net here.

Adopting Glide 4 therefore means raising the PHP floor, declaring `intervention/image` as a direct dependency, and migrating the image pipeline — a deliberate major, which is planned as a ground-up rebuild.

Minor and patch updates within Glide 3.x still come through; only `version-update:semver-major` is ignored.

Note that `.github/dependabot.yml` isn't in `ci.yml`'s paths filter, so no checks run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHnab9cF1hsT5dNuLGmK77
