### PR TITLE
chore: analyse and refactor workbench/ alongside src

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,12 +19,6 @@ parameters:
 			path: src/Actions/MultiUploadAction.php
 
 		-
-			message: '#^Parameter \#1 \$string of function str expects string\|null, Illuminate\\Support\\Stringable given\.$#'
-			identifier: argument.type
-			count: 3
-			path: src/Commands/InstallCommand.php
-
-		-
 			message: '#^Expression "match \(\$driver\) \{…" on a separate line does not do anything\.$#'
 			identifier: expr.resultUnused
 			count: 1
@@ -85,6 +79,12 @@ parameters:
 			path: src/Components/Forms/Uploader.php
 
 		-
+			message: '#^Expression on left side of \?\? is not nullable\.$#'
+			identifier: nullCoalesce.expr
+			count: 1
+			path: src/Components/Modals/Concerns/HasBreadcrumbs.php
+
+		-
 			message: '#^Call to an undefined method League\\Glide\\Api\\ApiInterface\:\:getImageManager\(\)\.$#'
 			identifier: method.notFound
 			count: 1
@@ -100,12 +100,6 @@ parameters:
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$id\.$#'
 			identifier: property.notFound
 			count: 3
-			path: src/Components/Modals/CuratorPanel.php
-
-		-
-			message: '#^Expression on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.expr
-			count: 1
 			path: src/Components/Modals/CuratorPanel.php
 
 		-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,7 +6,19 @@ parameters:
     level: 5
     paths:
         - src
+        # The Testbench workbench is dev-only but it is hand-written code that
+        # exercises this package's own public API, so it is analysed like anything else.
+        - workbench
+        # This package ships a real config/ directory, so it is analysed too.
         - config
+    excludePaths:
+        analyse:
+            # workbench/storage is gitignored, but it appears the moment anyone runs the
+            # workbench app and fills up with compiled Blade, which is not valid
+            # standalone PHP. CI never sees it, so without this the config passes in CI
+            # and is unusable locally. `(?)` marks the path optional so this does not
+            # itself hard-error in CI. The marker is only valid here, not in `paths`.
+            - workbench/storage (?)
     tmpDir: build/phpstan
     # composer.lock is gitignored, so CI resolves dependencies fresh on every run.
     # When a Filament or larastan release improves its type information, baselined

--- a/rector.php
+++ b/rector.php
@@ -8,6 +8,14 @@ try {
     return RectorConfig::configure()
         ->withPaths([
             __DIR__ . '/src',
+            // Dev-only, but hand-written — refactored on the same terms as src.
+            __DIR__ . '/workbench',
+        ])
+        // Compiled Blade under workbench/storage is gitignored but present locally
+        // once the workbench app has been run, and it is not valid standalone PHP.
+        // Unlike withPaths(), withSkip() tolerates a path that is not there.
+        ->withSkip([
+            __DIR__ . '/workbench/storage',
         ])
         ->withPreparedSets(
             deadCode: true,

--- a/workbench/database/migrations/2026_01_01_000001_create_posts_table.php
+++ b/workbench/database/migrations/2026_01_01_000001_create_posts_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('posts', function (Blueprint $table) {
+        Schema::create('posts', function (Blueprint $table): void {
             $table->id();
             $table->string('title');
             $table->longText('content')->nullable();

--- a/workbench/database/migrations/2026_01_01_000002_create_mediables_table.php
+++ b/workbench/database/migrations/2026_01_01_000002_create_mediables_table.php
@@ -10,7 +10,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::create('mediables', function (Blueprint $table) {
+        Schema::create('mediables', function (Blueprint $table): void {
             $table->id();
             $table->string('mediable_type');
             $table->unsignedBigInteger('mediable_id');


### PR DESCRIPTION
Backfills the `awcodes/.github` **workbench tooling-scope decision** ([awcodes/.github#6](https://github.com/awcodes/.github/pull/6), shipped in v1.4.1). This package moved onto the shared CI workflows before that decision landed, so rector and phpstan were still scoped to `src` (plus `config` for phpstan) and never saw the 16 hand-written PHP files under `workbench/`.

## Changes

**`phpstan.neon.dist`** — adds `workbench` to `paths`, and excludes `workbench/storage`, which is gitignored but fills with compiled Blade as soon as the workbench app is run (not valid standalone PHP: thousands of errors locally, zero in CI). The `(?)` optional marker keeps that exclude from hard-erroring in CI, where the directory never exists. That marker is only valid in `excludePaths`, not in `paths`.

**`rector.php`** — adds `workbench` to `withPaths()` and `workbench/storage` to `withSkip()`. `withSkip()` tolerates a path that does not exist, `withPaths()` does not, which is why the skip can be unconditional.

`vendor/larastan/larastan/extension.neon` stays in the phpstan includes: `phpstan/extension-installer` is **not** in `require-dev` here, so larastan is not auto-registered and the explicit include is load-bearing. (It appears in `config.allow-plugins`, which is a meaningless leftover.)

## Baseline

Regenerated with `--generate-baseline`, not hand-edited. It **shrank** rather than grew — `workbench/` reports no errors at level 5:

| | entries | errors |
|---|---|---|
| before | 48 | 65 |
| after | 47 | 62 |

Both deltas are pre-existing staleness unrelated to `workbench/`:

- Dropped the `InstallCommand.php` `str expects string|null` entry (count 3). That error is already covered by an `ignoreErrors` pattern in `phpstan.neon.dist`, so it was double-suppressed; regeneration removed the redundant baseline entry.
- Moved a `nullCoalesce.expr` entry from `src/Components/Modals/CuratorPanel.php` to `src/Components/Modals/Concerns/HasBreadcrumbs.php` — the code was extracted into that trait after the baseline was last generated.

No new baseline entries, so nothing here surfaces a latent bug.

## Rector pass

Two files changed, both mechanical, committed separately from the config change:

- `workbench/database/migrations/2026_01_01_000001_create_posts_table.php`
- `workbench/database/migrations/2026_01_01_000002_create_mediables_table.php`

Both are `AddClosureVoidReturnTypeWhereNoReturnRector` adding `: void` to a `Schema::create()` closure. No union types were emitted, so the known rector/pint `fully_qualified_strict_types` disagreement had no surface here. Pint then reported clean with zero changes (it already covered `workbench/`, since Pint scans the whole project), so there is no separate pint commit.

## Verification

- `vendor/bin/phpstan analyse --debug` confirms all **16** `workbench/` PHP files are scanned.
- `composer test` (refactor + lint + types + unit) passes locally: **238 tests, 565 assertions**, exit 0.
- Local PHP is 8.4 (Herd). The **8.5 matrix rows cannot be verified locally** — CI is the only evidence for those.

Runtime `require`, `.github/workflows/`, and the frozen `4.x` branch are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QxdNSNdqXRproytP5odgW