### PR TITLE
chore: analyse database/ with phpstan and rector

### DIFF
--- a/database/factories/MediaFactory.php
+++ b/database/factories/MediaFactory.php
@@ -40,27 +40,23 @@ class MediaFactory extends Factory
 
     public function private(): self
     {
-        return $this->state(function (array $attributes) {
-            return [
-                'visibility' => 'private',
-            ];
-        });
+        return $this->state(fn (array $attributes): array => [
+            'visibility' => 'private',
+        ]);
     }
 
     public function randomTimestamps(): self
     {
-        return $this->state(function (array $attributes) {
-            return [
-                'created_at' => Carbon::now()
-                    ->addDays(rand(-800, 0))
-                    ->addMinutes(rand(0, 60 * 23))
-                    ->addSeconds(rand(0, 60)),
-                'updated_at' => Carbon::now()
-                    ->addDays(rand(-799, 0))
-                    ->addMinutes(rand(0, 60 * 23))
-                    ->addSeconds(rand(0, 60)),
-            ];
-        });
+        return $this->state(fn (array $attributes): array => [
+            'created_at' => Carbon::now()
+                ->addDays(random_int(-800, 0))
+                ->addMinutes(random_int(0, 60 * 23))
+                ->addSeconds(random_int(0, 60)),
+            'updated_at' => Carbon::now()
+                ->addDays(random_int(-799, 0))
+                ->addMinutes(random_int(0, 60 * 23))
+                ->addSeconds(random_int(0, 60)),
+        ]);
     }
 
     public function fixturesPath(string $path): static
@@ -145,9 +141,9 @@ class MediaFactory extends Factory
             path: $this->getFixturesPath() . $filename,
             disk: $this->getDisk(),
             directory: $this->getDirectory(),
-            alt: $this->faker->words(rand(3, 8), true),
-            caption: $this->faker->words(rand(3, 8), true),
-            description: $this->faker->words(rand(3, 8), true),
+            alt: $this->faker->words(random_int(3, 8), true),
+            caption: $this->faker->words(random_int(3, 8), true),
+            description: $this->faker->words(random_int(3, 8), true),
         );
     }
 
@@ -169,9 +165,9 @@ class MediaFactory extends Factory
             path: $this->getFixturesPath() . $filename,
             disk: $this->getDisk(),
             directory: $this->getDirectory(),
-            alt: $this->faker->words(rand(3, 8), true),
-            caption: $this->faker->words(rand(3, 8), true),
-            description: $this->faker->words(rand(3, 8), true),
+            alt: $this->faker->words(random_int(3, 8), true),
+            caption: $this->faker->words(random_int(3, 8), true),
+            description: $this->faker->words(random_int(3, 8), true),
         );
     }
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,6 +11,9 @@ parameters:
         - workbench
         # This package ships a real config/ directory, so it is analysed too.
         - config
+        # Migrations and factories are shipped code. phpstan flags wrong-arity
+        # Blueprint calls here — the class of bug postal-codes#12 turned out to be.
+        - database
     excludePaths:
         analyse:
             # workbench/storage is gitignored, but it appears the moment anyone runs the

--- a/rector.php
+++ b/rector.php
@@ -10,6 +10,8 @@ try {
             __DIR__ . '/src',
             // Dev-only, but hand-written — refactored on the same terms as src.
             __DIR__ . '/workbench',
+            __DIR__ . '/config',
+            __DIR__ . '/database',
         ])
         // Compiled Blade under workbench/storage is gitignored but present locally
         // once the workbench app has been run, and it is not valid standalone PHP.


### PR DESCRIPTION
## Why

Pint already formats `database/` — the canonical `pint.json` declares no `exclude` — but phpstan and rector both listed `src` and `workbench` only. That is the same asymmetry [.github#6](https://github.com/awcodes/.github/pull/6) closed for `workbench/`: one of the four checks policing code the other two ignore.

**This is not hygiene.** Migrations and factories are shipped code, and phpstan's `arguments.count` check on them is precisely what would have caught [postal-codes#12](https://github.com/awcodes/postal-codes/issues/12):

```
$table->float('lat', 10, 8);   // Laravel 11+: float($column, $precision = 53)
```

PHP silently discards the extra positional argument, so the 8 decimal places vanished and the column lost precision on MySQL, PostgreSQL and SQL Server. Verified by temporarily restoring the buggy call and re-running:

```
Method Illuminate\Database\Schema\Blueprint::float() invoked with 3 parameters, 1-2 required.
  🪪  arguments.count
```

That is a **level-0** check. The bug shipped only because the directory was not in phpstan's paths.

## Cost

**Zero new baseline entries** — phpstan reports `[OK] No errors` across `src`, `workbench`, `config` and `database`.

## Verification

- `composer test` green: rector clean, pint clean, phpstan no errors, full suite passing.
- The rector pass was reviewed by hand rather than trusted, because `ClosureReturnTypeRector` is the rule implicated in [.github#8](https://github.com/awcodes/.github/issues/8) (rector and Pint silently mangling a fully-qualified union, with both tools then reporting clean). It emitted single `: array` return types here, not unions, so the trap had no surface. Pint then corrected `fn(` to `fn (` via `function_declaration`.
- `rand()` → `random_int()` in the factory is a genuine improvement, not just churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QxdNSNdqXRproytP5odgW
